### PR TITLE
Changes needed for ntopng to compile on OpenBSD

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,10 +3,10 @@ prefix = @prefix@
 datadir = @datadir@
 SHELL=/bin/sh
 OS := $(shell uname -s)
-HERE=@PWD@
+PWD=@PWD@
 GPP=@GPP@
-INSTALL_DIR=$(DESTDIR)@INSTALL_DIR@
-MAN_DIR=$(DESTDIR)@MAN_DIR@
+INSTALL_DIR=$(prefix)
+MAN_DIR=$(prefix)
 ######
 HAS_NDPI=$(shell pkg-config --exists libndpi; echo $$?)
 ifeq ($(HAS_NDPI), 0)
@@ -41,7 +41,11 @@ ifeq ($(HAS_LIBRRDTOOL), 0)
 	LIBRRDTOOL_LIB = $(shell pkg-config --libs librrd)
 else
 	LIBRRDTOOL_INC=-I$(LIBRRDTOOL_HOME)/src/
-	LIBRRDTOOL_LIB=$(LIBRRDTOOL_HOME)/src/.libs/librrd_th.a -lm -lgobject-2.0 -lgmodule-2.0 -ldl -lglib-2.0
+	ifeq ($(OS), OpenBSD)
+		LIBRRDTOOL_LIB=$(LIBRRDTOOL_HOME)/src/.libs/librrd_th.a -lm -lgobject-2.0 -lgmodule-2.0 -lglib-2.0	
+	else
+		LIBRRDTOOL_LIB=$(LIBRRDTOOL_HOME)/src/.libs/librrd_th.a -lm -lgobject-2.0 -lgmodule-2.0 -ldl -lglib-2.0
+	endif
 endif
 ######
 HTTPCLIENT_INC=${PWD}/third-party/http-client-c/src/

--- a/include/Flow.h
+++ b/include/Flow.h
@@ -139,9 +139,17 @@ class Flow : public GenericHashEntry {
   double toMs(const struct timeval *t);
   void timeval_diff(struct timeval *begin, const struct timeval *end, struct timeval *result, u_short divide_by_two) ;
 
+#ifdef __OpenBSD__
+  void updateTcpFlags(const struct bpf_timeval *when, u_int8_t flags, bool src2dst_direction);
+#else
   void updateTcpFlags(const struct timeval *when, u_int8_t flags, bool src2dst_direction);
+#endif
 
+#ifdef __OpenBSD__
+  void updateTcpSeqNum(const struct bpf_timeval *when, u_int32_t seq_num,
+#else
   void updateTcpSeqNum(const struct timeval *when, u_int32_t seq_num,
+#endif
 		       u_int32_t ack_seq_num, u_int8_t flags,
 		       u_int16_t payload_len, bool src2dst_direction);
 

--- a/include/NetworkInterface.h
+++ b/include/NetworkInterface.h
@@ -231,7 +231,11 @@ class NetworkInterface {
   void flushHostContacts();
   bool packet_dissector(const struct pcap_pkthdr *h, const u_char *packet,
 			int *a_shaper_id, int *b_shaper_id);
+#ifdef __OpenBSD__
+  bool packetProcessing(const struct bpf_timeval *when,
+#else
   bool packetProcessing(const struct timeval *when,
+#endif
 			const u_int64_t time,
 			struct ndpi_ethhdr *eth,
 			u_int16_t vlan_id,

--- a/include/ntop_includes.h
+++ b/include/ntop_includes.h
@@ -44,6 +44,7 @@
 #include <poll.h>
 
 #if defined(__OpenBSD__)
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -1430,8 +1430,11 @@ void Flow::addFlowStats(bool cli2srv_direction, u_int in_pkts, u_int in_bytes,
 }
 
 /* *************************************** */
-
+#ifdef __OpenBSD__
+void Flow::updateTcpFlags(const struct bpf_timeval *when, u_int8_t flags, bool src2dst_direction) {
+#else
 void Flow::updateTcpFlags(const struct timeval *when, u_int8_t flags, bool src2dst_direction) {
+#endif
 #if 0
   if((flags == TH_SYN)
      && ((src2dst_tcp_flags | dst2src_tcp_flags) == TH_SYN) /* SYN was already received */
@@ -1518,7 +1521,11 @@ u_int32_t Flow::getNextTcpSeq ( u_int8_t tcpFlags,
 
 /* *************************************** */
 
+#ifdef __OpenBSD__
+void Flow::updateTcpSeqNum(const struct bpf_timeval *when, u_int32_t seq_num,
+#else
 void Flow::updateTcpSeqNum(const struct timeval *when, u_int32_t seq_num,
+#endif
 			   u_int32_t ack_seq_num, u_int8_t flags,
 			   u_int16_t payload_Len, bool src2dst_direction) {
   u_int32_t next_seq_num;

--- a/src/Lua.cpp
+++ b/src/Lua.cpp
@@ -2814,8 +2814,13 @@ static int ntop_generate_csrf_value(lua_State* vm) {
 
   ntop->getTrace()->traceEvent(TRACE_INFO, "%s() called", __FUNCTION__);
 
+#ifdef __OpenBSD__
+  snprintf(random_a, sizeof(random_a), "%d", arc4random());
+  snprintf(random_b, sizeof(random_b), "%lu", time(NULL)*arc4random());
+#else
   snprintf(random_a, sizeof(random_a), "%d", rand());
   snprintf(random_b, sizeof(random_b), "%lu", time(NULL)*rand());
+#endif
 
   mg_md5(csrf, random_a, random_b, NULL);
 

--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -623,7 +623,11 @@ void NetworkInterface::flow_processing(ZMQ_Flow *zflow) {
     struct timeval when;
 
     when.tv_sec = (long)last_pkt_rcvd, when.tv_usec = 0;
+#ifdef __OpenBSD__
+    flow->updateTcpFlags((const struct bpf_timeval*)&when,
+#else
     flow->updateTcpFlags((const struct timeval*)&when,
+#endif
 			 zflow->tcp_flags, src2dst_direction);
   }
 
@@ -690,7 +694,11 @@ void NetworkInterface::dumpPacketTap(const struct pcap_pkthdr *h, const u_char *
 
 /* **************************************************** */
 
+#ifdef __OpenBSD__
+bool NetworkInterface::packetProcessing(const struct bpf_timeval *when,
+#else
 bool NetworkInterface::packetProcessing(const struct timeval *when,
+#endif
 					const u_int64_t time,
 					struct ndpi_ethhdr *eth,
 					u_int16_t vlan_id,

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -105,7 +105,11 @@ Ntop::Ntop(char *appName) {
     fixPath(path);
 
     if(stat(path, &statbuf) == 0) {
+#ifdef __OpenBSD__
+      strlcpy(install_dir, dirs[i], sizeof(install_dir));
+#else
       strcpy(install_dir, dirs[i]);
+#endif
       break;
     }
   }

--- a/src/PacketDumperTuntap.cpp
+++ b/src/PacketDumperTuntap.cpp
@@ -157,6 +157,32 @@ int PacketDumperTuntap::openTap(char *dev, /* user-definable interface name, eg.
 
 /* ********************************************* */
 
+#ifdef __OpenBSD__
+#define OPENBSD_TAPDEVICE_SIZE 32
+int PacketDumperTuntap::openTap(char *dev, /* user-definable interface name, eg. edge0 */ int mtu) {
+  int i;
+  char tap_device[OPENBSD_TAPDEVICE_SIZE];
+
+  for (i = 0; i < 255; i++) {
+    snprintf(tap_device, sizeof(tap_device), "/dev/tap%d", i);
+    this->fd = open(tap_device, O_RDWR);
+    if(this->fd > 0) {
+      ntop->getTrace()->traceEvent(TRACE_NORMAL, "Succesfully open %s", tap_device);
+      break;
+    }
+  }
+  if(this->fd < 0) {
+    ntop->getTrace()->traceEvent(TRACE_ERROR, "Unable to open tap device");
+    return(-1);
+  }
+
+  ntop->getTrace()->traceEvent(TRACE_NORMAL, "Interface tap%d up and running", i);
+  return(this->fd);
+}
+#endif
+
+/* ********************************************* */
+
 #ifdef WIN32
 
 int PacketDumperTuntap::openTap(char *dev, /* user-definable interface name, eg. edge0 */ int mtu) {


### PR DESCRIPTION
Hi Luca, 

commit 71414f65be84634ce04881a909bca235d6f4a0df is needed for ntopng to compile on OpenBSD, remaining changes address lack of '-ldl' in OpenBSD and various small changes relating to security (these are specific to OpenBSD).

Zbynek

