### PR TITLE
Fix duplicate handling to fix broken graphs for hosts

### DIFF
--- a/scripts/lua/modules/graph_utils.lua
+++ b/scripts/lua/modules/graph_utils.lua
@@ -306,13 +306,13 @@ function drawRRD(ifid, host, rrdFile, zoomLevel, baseurl, show_timeseries,
       names_cache = {}
       for i, n in ipairs(fnames) do
          -- handle duplicates
-         if (names_cache[prefixLabel] == nil) then
-	   names[num] = prefixLabel
-           names_cache[prefixLabel] = true
-	   -- if(prefixLabel ~= firstToUpper(n)) then names[num] = names[num] .. " (" .. firstToUpper(n)..")" end
-	   num = num + 1
-	   --io.write(prefixLabel.."\n")
-	   --print(num.."\n")
+         if (names_cache[n] == nil) then
+           names_cache[n] = true
+           names[num] = prefixLabel
+           if(host ~= nil) then names[num] = names[num] .. " (" .. firstToUpper(n)..")" end
+           num = num + 1
+           --io.write(prefixLabel.."\n")
+           --print(num.."\n")
          end
       end
 


### PR DESCRIPTION
Hosts historical graphs (Traffic, UDP, TCP)  are broken:
![image](https://cloud.githubusercontent.com/assets/1324566/8063594/e606d78e-0ed5-11e5-80b2-428c8dfc3696.png)

The PR fixes them:
![image](https://cloud.githubusercontent.com/assets/1324566/8063601/ed2b42a2-0ed5-11e5-9201-f776d786dac1.png)
