### PR TITLE
Top stats for hosts

### DIFF
--- a/scripts/lua/host_details.lua
+++ b/scripts/lua/host_details.lua
@@ -2029,7 +2029,7 @@ else
    rrdfile=_GET["rrd_file"]
 end
 
-drawRRD(ifId, hostinfo2hostkey(host_info), rrdfile, _GET["graph_zoom"], ntop.getHttpPrefix()..'/lua/host_details.lua?ifname='..ifId..'&'..hostinfo2url(host_info)..'&page=historical', 1, _GET["epoch"], nil, nil)
+drawRRD(ifId, hostinfo2hostkey(host_info), rrdfile, _GET["graph_zoom"], ntop.getHttpPrefix()..'/lua/host_details.lua?ifname='..ifId..'&'..hostinfo2url(host_info)..'&page=historical', 1, _GET["epoch"], nil, makeTopStatsScriptsArray())
 
 elseif(page == "aggregations") then
 print [[

--- a/scripts/lua/if_stats.lua
+++ b/scripts/lua/if_stats.lua
@@ -12,29 +12,6 @@ require "alert_utils"
 
 sendHTTPHeader('text/html; charset=iso-8859-1')
 
-local function makeTopStatsScriptsArray()
-   path = dirs.installdir .. "/scripts/lua/modules/top_scripts"
-   path = fixPath(path)
-   local files = ntop.readdir(path)
-   topArray = {}
-
-   for k,v in pairs(files) do
-      if(v ~= nil) then
-	 value = {}
-	 fn,ext = v:match("([^.]+).([^.]+)")
-	 mod = require("top_scripts."..fn)
-	 if(type(mod) ~= type(true)) then
-            value["name"] = mod.name
-            value["script"] = mod.infoScript
-            value["key"] = mod.infoScriptKey
-            value["levels"] = mod.numLevels
-            topArray[fn] = value
-	 end
-      end
-   end
-   return(topArray)
-end
-
 page = _GET["page"]
 if_name = _GET["if_name"]
 

--- a/scripts/lua/modules/lua_utils.lua
+++ b/scripts/lua/modules/lua_utils.lua
@@ -1553,3 +1553,26 @@ function maxRateToString(max_rate)
       end
    end
 end
+
+function makeTopStatsScriptsArray()
+   path = dirs.installdir .. "/scripts/lua/modules/top_scripts"
+   path = fixPath(path)
+   local files = ntop.readdir(path)
+   topArray = {}
+
+   for k,v in pairs(files) do
+      if(v ~= nil) then
+	 value = {}
+	 fn,ext = v:match("([^.]+).([^.]+)")
+	 mod = require("top_scripts."..fn)
+	 if(type(mod) ~= type(true)) then
+            value["name"] = mod.name
+            value["script"] = mod.infoScript
+            value["key"] = mod.infoScriptKey
+            value["levels"] = mod.numLevels
+            topArray[fn] = value
+	 end
+      end
+   end
+   return(topArray)
+end


### PR DESCRIPTION
Top stats table is missing for hosts graphs (historical page)

![image](https://cloud.githubusercontent.com/assets/1324566/8064213/a291ebb6-0ed9-11e5-94c9-388c449d29ab.png)