### PR TITLE
FreeBSD related changes

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -287,11 +287,12 @@ then
 	GMAKE="make"
 fi
 
-GPP=`which clang++`
+GPP=`which g++`
 if test x$GPP = x
 then
-	GPP="g++"
+       AC_MSG_RESULT(FATAL ERROR: g++ is not installed on your host) 
 fi
+
 
 GIT=`which git`
 if test x$GIT = x

--- a/src/PacketDumperTuntap.cpp
+++ b/src/PacketDumperTuntap.cpp
@@ -131,7 +131,7 @@ int PacketDumperTuntap::openTap(char *dev, /* user-definable interface name, eg.
 
 /* ********************************************* */
 
-#ifdef __FreeBSD
+#ifdef __FreeBSD__
 #define FREEBSD_TAPDEVICE_SIZE 32
 int PacketDumperTuntap::openTap(char *dev, /* user-definable interface name, eg. edge0 */ int mtu) {
   int i;


### PR DESCRIPTION
Hi Luca,

just two small commits to make ntopng compile on FreeBSD 10:

1. PacketDumperTunTap: it needed changed macro
2. config.guess: ntopng doesn't compile with clang (on FreeBSD), so in my poinion there is no point testing for it at all.

Zbynek