### PR TITLE
Re-enable clang compiler.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -287,12 +287,11 @@ then
 	GMAKE="make"
 fi
 
-GPP=`which g++`
+GPP=`which clang++`
 if test x$GPP = x
 then
-       AC_MSG_RESULT(FATAL ERROR: g++ is not installed on your host) 
+	GPP="g++"
 fi
-
 
 GIT=`which git`
 if test x$GIT = x


### PR DESCRIPTION
Current FreeBSD 10.1 is failing to compile with GCC, and reverting this
commit is the only thing necessary for a successful build.

Ubuntu 14.04 with GCC is producing a successful build, but I've had the
binary segfault just after starting.  After reverting this, and
installing clang, builds are successful and do not segfault.

This reverts commit 37f407a7ccd9e0c4df17fb7ca9664781e4c14dce.