### PR TITLE
src/NetworkInterface.cpp: fix support for libpcap Raw IP capture

### DIFF
--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -1058,7 +1058,8 @@ bool NetworkInterface::packet_dissector(const struct pcap_pkthdr *h,
     eth_type = (packet[14] << 8) + packet[15];
     ip_offset = 16;
     incStats(0, NDPI_PROTOCOL_UNKNOWN, h->len, 1, 24 /* 8 Preamble + 4 CRC + 12 IFG */);
-  } else if(pcap_datalink_type == 101 /* Linux TUN/TAP device in TUN mode; Raw IP capture */) {
+#ifdef DLT_RAW
+  } else if(pcap_datalink_type == DLT_RAW /* Linux TUN/TAP device in TUN mode; Raw IP capture */) {
     switch((packet[0] & 0xf0) >> 4) {
     case 4:
       eth_type = ETHERTYPE_IP;
@@ -1072,6 +1073,7 @@ bool NetworkInterface::packet_dissector(const struct pcap_pkthdr *h,
     memset(&dummy_ethernet, 0, sizeof(dummy_ethernet));
     ethernet = (struct ndpi_ethhdr *)&dummy_ethernet;
     ip_offset = 0;
+#endif /* DLT_RAW */
   } else {
     incStats(0, NDPI_PROTOCOL_UNKNOWN, h->len, 1, 24 /* 8 Preamble + 4 CRC + 12 IFG */);
     return(pass_verdict);


### PR DESCRIPTION
Hello,

The actual Raw IP type returned by `get_datalink()` is `12` for Linux and `14` for OpenBSD; not `101` as specified in http://www.tcpdump.org/linktypes.html (that is the `LINKTYPE_` value).

I checked with `gdb` that the value is actually `12` on Linux. Also, the definition for `DLT_RAW` in `/usr/include/pcap/bpf.h` is clear enough...

I'm using `DLT_RAW` now, and I've wrapped the code in `#ifdef`'s in case `DLT_RAW` isn't defined for some OS. (I originally wanted to avoid this, and got bitten...)

Best,
Vittorio G