### PR TITLE
src/HistoricalInterface.cpp: create flowsManager instance for the Historical interface

### DIFF
--- a/src/HistoricalInterface.cpp
+++ b/src/HistoricalInterface.cpp
@@ -34,6 +34,10 @@ HistoricalInterface::HistoricalInterface(const char *_endpoint)
     resetStats();
     purge_idle_flows_hosts = false;
 
+  flowsManager = new FlowsManager(this);
+  if (!flowsManager)
+    ntop->getTrace()->traceEvent(TRACE_WARNING, "Could not allocate FlowsManager for Historical interface");
+
   /* Create view for this interface so that it is visible in the GUI */
   view = new NetworkInterfaceView(this);
   if (!view)


### PR DESCRIPTION
Hello,

This commit avoids a segmentation fault when opening the Flows page for the Historical interface in the web interface.

It happened because the `flowsManager` was not being initialized for the `HistoricalInterface`.

So when the `FlowsManager::select` function was trying to call `intf->get_flows_hash()->walk(flows_select_walker, (void*)&info);`, `intf` could not be retrieved because `this` was `null`, and the program segfaulted.

Best,
Vittorio G