### PR TITLE
src/PacketDumper.cpp: correctly set interface datalink type for the PacketDumper.

### DIFF
--- a/src/PacketDumper.cpp
+++ b/src/PacketDumper.cpp
@@ -32,7 +32,7 @@ PacketDumper::PacketDumper(NetworkInterface *i) {
   if((name[0] == 'l') && (name[1] == 'o'))
     iface_type = DLT_NULL;
   else
-    iface_type = DLT_EN10MB;
+    iface_type = i->get_datalink();
 }
 
 /* ********************************************* */


### PR DESCRIPTION
Hello,

This commit fixes packet dumping for pcap interfaces such as TUN/TAP in TUN mode, ipip tunnels, sit (IPv6 over IP) tunnels.

Best regards,
Vittorio G