### PR TITLE
fixed init script exit code

### DIFF
--- a/packages/etc/init.d/ntopng
+++ b/packages/etc/init.d/ntopng
@@ -220,6 +220,7 @@ status_ntopng() {
         echo "ntopng running as ${PID}"
     else
 	echo "ntopng is not running"
+	exit 1
     fi
 
     return 0


### PR DESCRIPTION
Init script is exiting with 0 when ntopng is not running.  Fixed to exit with 1,