### PR TITLE
batman-adv packet dissector support

### DIFF
--- a/include/NetworkInterface.h
+++ b/include/NetworkInterface.h
@@ -156,6 +156,7 @@ class NetworkInterface {
   bool checkIdle();
   void dumpPacketDisk(const struct pcap_pkthdr *h, const u_char *packet, dump_reason reason);
   void dumpPacketTap(const struct pcap_pkthdr *h, const u_char *packet, dump_reason reason);
+  u_char* antenna_mac; 
 
  public:
   /**
@@ -251,7 +252,6 @@ class NetworkInterface {
   virtual void lua(lua_State* vm);
   void getnDPIProtocols(lua_State *vm);
   void getActiveHostsList(lua_State* vm, vm_ptree *vp, bool host_details, bool local_only);
-  void getCommunityHostsList(lua_State* vm, vm_ptree *vp, bool host_details, int community_id);
   void getFlowsStats(lua_State* vm);
   int  retrieve(lua_State* vm, patricia_tree_t *allowed_hosts, char *SQL);
   void getFlowPeersList(lua_State* vm, patricia_tree_t *allowed_hosts, char *numIP, u_int16_t vlanId);
@@ -329,6 +329,7 @@ class NetworkInterface {
 
   inline HostHash* get_hosts_hash() { return(hosts_hash);       }
   inline bool is_bridge_interface() { return(bridge_interface); }
+  u_char* getAntennaMac()			{return (antenna_mac);}
 };
 
 #endif /* _NETWORK_INTERFACE_H_ */

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -169,6 +169,35 @@
 #define CONST_EST_MAX_FLOWS            200000
 #define CONST_EST_MAX_HOSTS            200000
 
+#define BATADV_COMPAT_VERSION_15 15
+#define BATADV_COMPAT_VERSION_14 14
+
+//batman-adv compat version 14 packet types
+#define BATADV14_IV_OGM		 0x01
+#define BATADV14_ICMP		 0x02
+#define BATADV14_UNICAST	 0x03
+#define BATADV14_BCAST		 0x04
+#define BATADV14_VIS		 0x05
+#define BATADV14_UNICAST_FRAG	 0x06
+#define BATADV14_TT_QUERY	 0x07 
+#define BATADV14_ROAM_ADV	 0x08 
+#define BATADV14_UNICAST_4ADDR	 0x09
+#define BATADV14_CODED		 0x0a
+
+
+// batman-adv compat version 15 packet types
+#define BATADV15_IV_OGM          0x00
+#define BATADV15_BCAST           0x01
+#define BATADV15_CODED           0x02
+#define BATADV15_UNICAST_MIN     0x40
+#define BATADV15_UNICAST         0x40
+#define BATADV15_UNICAST_FRAG    0x41
+#define BATADV15_UNICAST_4ADDR   0x42
+#define BATADV15_ICMP            0x43
+#define BATADV15_UNICAST_TVLV    0x44
+#define BATADV15_UNICAST_MAX     0x7f
+
+
 #ifndef TH_FIN
 #define	TH_FIN	0x01
 #endif


### PR DESCRIPTION
with this patch ntopng can dissect batman-adv[1] version 2013 and 2014 packets and retrieve mac address information from nodes

[1] http://www.open-mesh.org/projects/batman-adv/wiki 