### PR TITLE
ntopng batman-adv dissector

### DIFF
--- a/include/Host.h
+++ b/include/Host.h
@@ -95,6 +95,7 @@ class Host : public GenericHost {
   char* getJSON();
   inline void setOS(char *_os)                 { if(os[0] == '\0') snprintf(os, sizeof(os), "%s", _os); }
   inline IpAddress* get_ip()                   { return(ip);               }
+  void set_antenna_mac(char *m);  
   void set_mac(char *m);
   inline bool is_blacklisted()                 { return(blacklisted_host); }
   inline u_int8_t*  get_mac()                  { return(mac_address);      }

--- a/include/NetworkInterface.h
+++ b/include/NetworkInterface.h
@@ -156,6 +156,7 @@ class NetworkInterface {
   bool checkIdle();
   void dumpPacketDisk(const struct pcap_pkthdr *h, const u_char *packet, dump_reason reason);
   void dumpPacketTap(const struct pcap_pkthdr *h, const u_char *packet, dump_reason reason);
+  u_char* antenna_mac; 
 
  public:
   /**
@@ -329,6 +330,7 @@ class NetworkInterface {
 
   inline HostHash* get_hosts_hash() { return(hosts_hash);       }
   inline bool is_bridge_interface() { return(bridge_interface); }
+  u_char* getAntennaMac()			{return (antenna_mac);}
 };
 
 #endif /* _NETWORK_INTERFACE_H_ */

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -169,6 +169,35 @@
 #define CONST_EST_MAX_FLOWS            200000
 #define CONST_EST_MAX_HOSTS            200000
 
+#define BATADV_COMPAT_VERSION_15 15
+#define BATADV_COMPAT_VERSION_14 14
+
+//batman-adv compat version 14 packet types
+#define BATADV14_IV_OGM		 0x01
+#define BATADV14_ICMP		 0x02
+#define BATADV14_UNICAST	 0x03
+#define BATADV14_BCAST		 0x04
+#define BATADV14_VIS		 0x05
+#define BATADV14_UNICAST_FRAG	 0x06
+#define BATADV14_TT_QUERY	 0x07 
+#define BATADV14_ROAM_ADV	 0x08 
+#define BATADV14_UNICAST_4ADDR	 0x09
+#define BATADV14_CODED		 0x0a
+
+
+// batman-adv compat version 15 packet types
+#define BATADV15_IV_OGM          0x00
+#define BATADV15_BCAST           0x01
+#define BATADV15_CODED           0x02
+#define BATADV15_UNICAST_MIN     0x40
+#define BATADV15_UNICAST         0x40
+#define BATADV15_UNICAST_FRAG    0x41
+#define BATADV15_UNICAST_4ADDR   0x42
+#define BATADV15_ICMP            0x43
+#define BATADV15_UNICAST_TVLV    0x44
+#define BATADV15_UNICAST_MAX     0x7f
+
+
 #ifndef TH_FIN
 #define	TH_FIN	0x01
 #endif

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -170,6 +170,10 @@ void Host::initialize(u_int8_t mac[6], u_int16_t _vlanId, bool init_all) {
 
   memset(antenna_mac_address, 0, sizeof(antenna_mac_address));
 
+  u_char* ant_mac =  iface->getAntennaMac();
+
+  if(ant_mac) memcpy(antenna_mac_address, ant_mac, 6); 
+  
   if(mac) memcpy(mac_address, mac, 6); else memset(mac_address, 0, 6);
 
   //if(_vlanId > 0) ntop->getTrace()->traceEvent(TRACE_NORMAL, "VLAN => %d", _vlanId);
@@ -427,6 +431,19 @@ void Host::set_mac(char *m) {
   mac_address[0] = mac[0], mac_address[1] = mac[1],
     mac_address[2] = mac[2], mac_address[3] = mac[3],
     mac_address[4] = mac[4], mac_address[5] = mac[5];
+}
+
+/* *************************************** */
+
+void Host::set_antenna_mac(char *m) {
+  u_int32_t mac[6] = { 0 };
+
+  sscanf(m, "%u:%u:%u:%u:%u:%u",
+         &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+
+  antenna_mac_address[0] = mac[0], antenna_mac_address[1] = mac[1],
+  antenna_mac_address[2] = mac[2], antenna_mac_address[3] = mac[3],
+  antenna_mac_address[4] = mac[4], antenna_mac_address[5] = mac[5];
 }
 
 /* *************************************** */

--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -1106,11 +1106,124 @@ bool NetworkInterface::packet_dissector(const struct pcap_pkthdr *h,
 
   if(eth_type == ETHERTYPE_BATMAN) {
     /* ethernet now contains the L2 layer of the antennas */
-    ip_offset += 10;
+
+    u_char orig_dest[6], orig_src[6];
+
+    u_int8_t bp_type = (u_int8_t) (packet[ip_offset]);
+    u_int8_t version = (u_int8_t) (packet[ip_offset+1]);
+
+    if(version == BATADV_COMPAT_VERSION_15){
+      switch(bp_type){
+        case BATADV15_IV_OGM:
+          ip_offset += 24;
+          break;
+        case BATADV15_BCAST: 
+          orig_src[0] = packet[ip_offset+8];
+          orig_src[1] = packet[ip_offset+9];
+          orig_src[2] = packet[ip_offset+10];
+          orig_src[3] = packet[ip_offset+11];
+          orig_src[4] = packet[ip_offset+12];
+          orig_src[5] = packet[ip_offset+13];
+          ip_offset += 14;
+          break;
+        case BATADV15_CODED: 
+          ip_offset += 46;
+          break;    
+        case BATADV15_UNICAST:
+          orig_dest[0] = packet[ip_offset+4];
+          orig_dest[1] = packet[ip_offset+5];
+          orig_dest[2] = packet[ip_offset+6];
+          orig_dest[3] = packet[ip_offset+7];
+          orig_dest[4] = packet[ip_offset+8];
+          orig_dest[5] = packet[ip_offset+9];
+          ip_offset += 10;		
+          break;         
+        case BATADV15_UNICAST_FRAG:
+          ip_offset += 20;
+          break;    
+        case BATADV15_UNICAST_4ADDR:   
+          ip_offset += 18;
+          break;
+        case BATADV15_ICMP:            
+          ip_offset += 20;
+          break;
+        case BATADV15_UNICAST_TVLV:    
+          ip_offset += 20;	
+          break;
+        default:
+          fprintf(stderr,"Unknown packet type for batman-adv 2014");
+	  exit(EXIT_FAILURE);
+	  break;
+      }
+    }else if(version == BATADV_COMPAT_VERSION_14){
+       switch(bp_type){
+         case BATADV14_IV_OGM:
+           ip_offset += 26;
+           break;
+         case BATADV14_ICMP:            
+           ip_offset += 20;
+           break;
+         case BATADV14_UNICAST:
+           orig_dest[0] = packet[ip_offset+4];
+           orig_dest[1] = packet[ip_offset+5];
+           orig_dest[2] = packet[ip_offset+6];
+           orig_dest[3] = packet[ip_offset+7];
+           orig_dest[4] = packet[ip_offset+8];
+           orig_dest[5] = packet[ip_offset+9];
+           ip_offset += 10;		
+           break;         
+         case BATADV14_BCAST: 
+           orig_src[0] = packet[ip_offset+8];
+           orig_src[1] = packet[ip_offset+9];
+           orig_src[2] = packet[ip_offset+10];
+           orig_src[3] = packet[ip_offset+11];
+           orig_src[4] = packet[ip_offset+12];
+           orig_src[5] = packet[ip_offset+13];
+           ip_offset += 14;
+           break;
+         case BATADV14_VIS: 
+           ip_offset += 28;
+           break;
+         case BATADV14_UNICAST_FRAG:
+           ip_offset += 20;
+           break;    
+         case BATADV14_TT_QUERY:
+           ip_offset += 19;
+           break;
+         case BATADV14_ROAM_ADV:
+           ip_offset += 22;
+           break;
+         case BATADV14_UNICAST_4ADDR:   
+           ip_offset += 18;
+           break;
+         case BATADV14_CODED: 
+           ip_offset += 46;
+           break;    
+         default:
+           fprintf(stderr,"Unknown packet type for batman-adv 2013");
+           exit(EXIT_FAILURE);
+           break;
+       }
+     }else{
+       fprintf(stderr,"ntopng supports only batman-adv version 2013 and 2014");
+       exit(EXIT_FAILURE);
+      }
+
+
     ethernet = (struct ndpi_ethhdr *) &packet[ip_offset];
     eth_type = (packet[ip_offset + 12] << 8) + packet[ip_offset + 13];
     ip_offset += sizeof(struct ndpi_ethhdr);
+
+    if( ((bp_type == BATADV14_BCAST) || (bp_type == BATADV15_BCAST)) && memcmp(orig_src,ethernet->h_source,6) != 0 ){
+	antenna_mac=orig_src;
+    }  	
+    if(((bp_type == BATADV14_UNICAST) || (bp_type == BATADV15_UNICAST)) &&  memcmp(orig_dest,ethernet->h_dest,6) != 0  ){
+	antenna_mac=orig_dest;
+    }
+
+
   }
+
 
   switch(eth_type) {
   case ETHERTYPE_PPOE:


### PR DESCRIPTION
This patch aims to add support to ntopng to visualize antennas of mesh networks which use batman-adv routing protocol version 2013 or 2014. 