### PR TITLE
Respect HTTPPrefix for search box submit

### DIFF
--- a/scripts/lua/inc/search_host_box.lua
+++ b/scripts/lua/inc/search_host_box.lua
@@ -3,7 +3,9 @@
 --
 
 print [[
-	 <li><form action="/lua/host_details.lua">
+	 <li><form action="]]
+print (ntop.getHttpPrefix())
+print [[/lua/host_details.lua">
 ]]
 
 -- FIX: show notifications to the user


### PR DESCRIPTION
Right now by fireing up the search it redirects to the wrong page if ntopng is behind a reverse proxy with another http prefix.
