### PR TITLE
Add snapcraft.yaml to build a ntopng snap.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,7 @@ logobase.jpg
 logobase.png
 representations.aird
 third-party/libcrafter/
-
+*.snap
+prime/
+stage/
+parts/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,72 @@
+name: ntopng
+version: dev
+summary: High-speed web-based traffic analysis and flow collection.
+description: ntopng is the next generation version of the original ntop, a network traffic probe that shows the network usage, similar to what the popular top Unix command does.
+confinement: strict
+
+apps:
+    ntopng:
+        daemon: simple
+        command: bin/start-ntopng.sh
+        plugs:
+           - network-bind
+           - network-control
+    redis-server:
+        daemon: simple
+        command: bin/start-redis.sh
+        plugs:
+            - network-bind
+
+parts:
+    ndpi:
+        plugin: copy
+        source: https://github.com/ntop/nDPI.git
+        files: {}
+    ntopng-init:
+        plugin: copy
+        source: https://github.com/ntop/ntopng.git
+        after:
+            - ndpi
+        files:
+            '*': .
+            '../../ndpi/build/*': nDPI/
+        stage:
+            - -*
+        snap:
+            - -*
+    ntopng:
+        plugin: autotools
+        source: parts/ntopng-init/install
+        after:
+            - ntopng-init
+        build-packages:
+            - libxml2-dev
+            - libpcap-dev
+            - libsqlite3-dev
+            - libhiredis-dev
+            - libgeoip-dev
+            - libcurl4-openssl-dev
+            - libpango1.0-dev
+            - libcairo2-dev
+            - libpng12-dev
+            - libmysqlclient-dev
+            - libnetfilter-queue-dev
+            - zlib1g-dev
+            - libzmq3-dev
+    redis:
+        plugin: make
+        source: http://download.redis.io/releases/redis-3.2.3.tar.gz
+        make-install-var: PREFIX
+    daemons:
+        plugin: copy
+        source: ./snappy/
+        files:
+            start-redis.sh: bin/start-redis.sh
+            start-ntopng.sh: bin/start-ntopng.sh
+    netcat:
+        plugin: autotools
+        source: http://sourceforge.net/projects/netcat/files/netcat/0.7.1/netcat-0.7.1.tar.gz
+        stage:
+            - bin/netcat
+        snap:
+            - bin/netcat

--- a/snappy/start-ntopng.sh
+++ b/snappy/start-ntopng.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Wait for redis daemon to start accepting connections.
+while ! $SNAP/bin/netcat -z localhost 6379; do sleep 0.1; done
+
+# Get the network interfaces for ntopng to collect.
+nics=(/sys/class/net/*)
+
+# Start ntopng on the correct interfaces.
+$SNAP/bin/ntopng -d "$SNAP_COMMON" -t "$SNAP/share/ntopng" -1 "$SNAP/share/ntopng/httpdocs" -2 "$SNAP/share/ntopng/scripts" -3 "$SNAP/share/ntopng/scripts/callbacks" -s "${nics[@]//\/sys\/class\/net\//-i}"
+

--- a/snappy/start-redis.sh
+++ b/snappy/start-redis.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cat <<EOF >"$SNAP_DATA/redis.conf"
+bind 127.0.0.1
+EOF
+
+$SNAP/bin/redis-server "$SNAP_DATA/redis.conf"


### PR DESCRIPTION
This adds the ability to create a snap of ntopng to quickly allow users to get a working ntopng without any configuration required. For information on what a snap is and how it is used checkout snapcraft.io. Snappy is currently installed by default in Ubuntu 16.04 LTS and is in the process of landing in other distributions.

This quickly allows you to get tip of dev into peoples hands to test and promote builds to stable use. I have done this in an example snap in my namespace for Ubuntu. You can easily give this a try on Ubuntu 16.04 LTS with:

sudo snap install ntopng-blake
sudo snap connect ntopng-blake:network-control ubuntu-core:network-control
sudo systemctl restart snap.ntopng-blake.ntopng.service

Now you can access it at http://localhost:3000 with default user and password.
