### PR TITLE
Activity detection changes

### DIFF
--- a/include/ActivityFilters.h
+++ b/include/ActivityFilters.h
@@ -34,12 +34,17 @@ typedef unsigned int uint;
 class Flow;
 
 typedef enum {
-  activity_filter_all,
+  activity_filter_all = 0,
   activity_filter_sma,
   activity_filter_wma,
   activity_filter_command_sequence,
   activity_filter_web,
   activity_filter_metrics_test,
+  
+  ActivityFiltersN /* Unused as value but useful to
+       getting the number of elements
+       in this datastructure
+    */
 } ActivityFilterID;
 
 typedef union {
@@ -136,12 +141,7 @@ typedef bool (activity_filter_t)(const activity_filter_config *,
 				 activity_filter_status *,
 				 Flow *, const struct timeval *,
 				 bool, uint16_t);
-				
-activity_filter_t activity_filter_fun_all;
-activity_filter_t activity_filter_fun_sma;
-activity_filter_t activity_filter_fun_wma;
-activity_filter_t activity_filter_fun_command_sequence;
-activity_filter_t activity_filter_fun_web;
-activity_filter_t activity_filter_fun_metrics_test;
+
+extern activity_filter_t* activity_filter_funcs[];
 
 #endif

--- a/include/ActivityFilters.h
+++ b/include/ActivityFilters.h
@@ -78,6 +78,7 @@ typedef union {
     uint minbytes;
     uint maxinterval;
     bool serverdominant;
+    bool forceWebProfile;
   } web;
 } activity_filter_config;
 

--- a/include/ActivityFilters.h
+++ b/include/ActivityFilters.h
@@ -39,6 +39,7 @@ typedef enum {
   activity_filter_wma,
   activity_filter_command_sequence,
   activity_filter_web,
+  activity_filter_ratio,
   activity_filter_metrics_test,
   
   ActivityFiltersN /* Unused as value but useful to
@@ -80,6 +81,12 @@ typedef union {
     bool serverdominant;
     bool forceWebProfile;
   } web;
+
+  struct {
+    uint numsamples;
+    uint minbytes;
+    float clisrv_ratio;
+  } ratio;
 } activity_filter_config;
 
 typedef union {
@@ -116,6 +123,13 @@ typedef union {
     uint8_t samples;
     bool detected;
   } web;
+
+  struct {
+    uint64_t cliBytes;
+    uint64_t srvBytes;
+    uint samples;
+    bool detected;
+  } ratio;
 
   struct {    
     uint16_t sizes[ACTIVITY_FILTER_METRICS_SAMPLES];

--- a/include/Flow.h
+++ b/include/Flow.h
@@ -40,10 +40,12 @@ typedef struct {
 } FlowPacketStats;
 
 typedef struct {
-  activity_filter_t * filter;
+  ActivityFilterID filterId;
   activity_filter_config config;
   activity_filter_status status;
   UserActivityID activityId;
+  bool filterSet;
+  bool activitySet;
 } FlowActivityDetection;
 
 typedef enum {
@@ -359,10 +361,11 @@ class Flow : public GenericHashEntry {
   inline FlowState getFlowState()                   { return(state);                          }
   inline bool      isEstablished()                  { return state == flow_state_established; }
   
-  void setActivityFilter(activity_filter_t * filter, const activity_filter_config * config);
+  void setActivityFilter(ActivityFilterID fid, const activity_filter_config * config);
+  inline bool getActivityFilterId(ActivityFilterID *out) { if(activityDetection.filterSet) {*out = activityDetection.filterId; return true;} else return false; }
   bool invokeActivityFilter(const struct timeval *when, bool cli2srv, u_int16_t payload_len);
-  inline void setActivityId(UserActivityID id)      { activityDetection.activityId = id; }
-  inline UserActivityID getActivityId()             { return(activityDetection.activityId); }
+  inline void setActivityId(UserActivityID id)      { activityDetection.activityId = id; activityDetection.activitySet = true; }
+  inline bool getActivityId(UserActivityID *out)   { if(activityDetection.activitySet) {*out = activityDetection.activityId; return true;} else return false; }
 };
 
 #endif /* _FLOW_H_ */

--- a/include/NetworkInterface.h
+++ b/include/NetworkInterface.h
@@ -378,6 +378,6 @@ class NetworkInterface {
 };
 
 const char * getActivityName(UserActivityID id);
-UserActivityID getActivityId(const char * name);
+bool getActivityId(const char * name, UserActivityID * out);
 
 #endif /* _NETWORK_INTERFACE_H_ */

--- a/include/ntop_typedefs.h
+++ b/include/ntop_typedefs.h
@@ -229,6 +229,7 @@ typedef enum {
   user_activity_chat,
   user_activity_game,
   user_activity_remote_control,
+  user_activity_facebook,
 
   UserActivitiesN /* Unused as value but useful to
 		     getting the number of elements

--- a/include/ntop_typedefs.h
+++ b/include/ntop_typedefs.h
@@ -218,8 +218,7 @@ typedef enum {
 } LuaCallback;
 
 typedef enum {
-  user_activity_none = 0,
-  user_activity_other,
+  user_activity_other = 0,
   user_activity_web,
   user_activity_media,
   user_activity_vpn,
@@ -227,7 +226,6 @@ typedef enum {
   user_activity_mail_send,
   user_activity_file_sharing,
   user_activity_file_transfer,
-  user_activity_application,
   user_activity_chat,
   user_activity_game,
   user_activity_remote_control,

--- a/scripts/lua/host_details.lua
+++ b/scripts/lua/host_details.lua
@@ -1071,12 +1071,12 @@ print [[
 -- Host activity stats
 if host["localhost"] == true then
    print [[ <tr><th>Protocol Activity</th><td colspan=2>
-      <div style='margin-top:0.5em; margin-bottom:2em;'>
+      <div style='margin-top:0.5em;'>
          <input type="radio" name="showmode" value="updown" onclick="setShowMode(this.value)" checked> User Traffic<br>
          <input type="radio" name="showmode" value="bg" onclick="setShowMode(this.value)"> Background Traffic
       </div>
 
-      <div id="userctivity"></div>
+      <div id="userctivity" style='margin:2em 0 2em 0;'></div>
 
       <script src="]] print(ntop.getHttpPrefix()) print [[/js/cubism.v1.js"></script>
       <script src="]] print(ntop.getHttpPrefix()) print [[/js/cubism.rrd-server.js"></script>
@@ -1122,7 +1122,7 @@ if host["localhost"] == true then
                   $('#userctivity').empty();
                   
                   var metrics = [];
-                  JSON.parse(content).map(function(activity) {
+                  JSON.parse(content).sort().map(function(activity) {
                      metrics.push(rrdserver.metric(activitiesurl+"&activity="+activity, activity, mode === "bg"));
                   });
 

--- a/src/ActivityFilters.cpp
+++ b/src/ActivityFilters.cpp
@@ -23,7 +23,7 @@
 
 /* ********************************************************************** */
 
-bool activity_filter_fun_all(const activity_filter_config * config,
+static bool activity_filter_fun_all(const activity_filter_config * config,
 			      activity_filter_status * status, Flow * flow,
 			      const struct timeval *when,
 			      bool cli2srv, uint16_t payload_len) {
@@ -33,7 +33,7 @@ bool activity_filter_fun_all(const activity_filter_config * config,
 /* ********************************************************************** */
 
 /* Simple Moving Average with optional time bounds */
-bool activity_filter_fun_sma(const activity_filter_config * config,
+static bool activity_filter_fun_sma(const activity_filter_config * config,
 				      activity_filter_status * status, Flow * flow,
 				      const struct timeval *when,
 				      bool cli2srv, uint16_t payload_len) {
@@ -89,7 +89,7 @@ bool activity_filter_fun_sma(const activity_filter_config * config,
 /* ********************************************************************** */
 
 /* Weighted Moving Average scaling with inter-packed-delay seconds and optional aggregation */
-bool activity_filter_fun_wma(const activity_filter_config * config,
+static bool activity_filter_fun_wma(const activity_filter_config * config,
 				      activity_filter_status * status, Flow * flow,
 				      const struct timeval *when,
 				      bool cli2srv, uint16_t payload_len) {
@@ -146,7 +146,7 @@ bool activity_filter_fun_wma(const activity_filter_config * config,
  * 
  * Assumes client sends an ACK with no data when receiving multiple command replies.
  */
-bool activity_filter_fun_command_sequence(const activity_filter_config * config,
+static bool activity_filter_fun_command_sequence(const activity_filter_config * config,
 					  activity_filter_status * status, Flow * flow,
 					  const struct timeval *when,
 					  bool cli2srv, uint16_t payload_len) {
@@ -199,7 +199,7 @@ bool activity_filter_fun_command_sequence(const activity_filter_config * config,
 
 /* ********************************************************************** */
 
-bool activity_filter_fun_web(const activity_filter_config * config,
+static bool activity_filter_fun_web(const activity_filter_config * config,
 			     activity_filter_status * status, Flow * flow,
 			     const struct timeval *when,
 			     bool cli2srv, uint16_t payload_len) {
@@ -248,7 +248,7 @@ bool activity_filter_fun_web(const activity_filter_config * config,
 /* ********************************************************************** */
 
 /* This fitler is just for testing purposes. */
-bool activity_filter_fun_metrics_test(const activity_filter_config * config,
+static bool activity_filter_fun_metrics_test(const activity_filter_config * config,
 			     activity_filter_status * status, Flow * flow,
 			     const struct timeval *when,
 			     bool cli2srv, uint16_t payload_len) {
@@ -315,3 +315,16 @@ bool activity_filter_fun_metrics_test(const activity_filter_config * config,
   
   return rv;
 }
+
+/* ********************************************************************** */
+
+activity_filter_t* activity_filter_funcs[] = {
+  activity_filter_fun_all,
+  activity_filter_fun_sma,
+  activity_filter_fun_wma,
+  activity_filter_fun_command_sequence,
+  activity_filter_fun_web,
+  activity_filter_fun_metrics_test,
+};
+
+COMPILE_TIME_ASSERT (COUNT_OF(activity_filter_funcs) == ActivityFiltersN);

--- a/src/ActivityFilters.cpp
+++ b/src/ActivityFilters.cpp
@@ -229,6 +229,9 @@ static bool activity_filter_fun_web(const activity_filter_config * config,
              (!config->web.serverdominant || status->web.srvBytes > status->web.cliBytes)
         ) {
             status->web.detected = true;
+            UserActivityID uaid;
+            if (config->web.forceWebProfile && (!flow->getActivityId(&uaid) || uaid == user_activity_other))
+              flow->setActivityId(user_activity_web);
         }
 
         if (status->web.samples >= config->web.numsamples) {

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -2546,20 +2546,21 @@ FlowStatus Flow::getFlowStatus() {
 
 /* ***************************************************** */
 
-void Flow::setActivityFilter(activity_filter_t * filter, const activity_filter_config * config) {  
-  if (filter && config) {
-    activityDetection.filter = filter;
+void Flow::setActivityFilter(ActivityFilterID fid, const activity_filter_config * config) {
+  if (fid < ActivityFiltersN && config) {
+    activityDetection.filterId = fid;
+    activityDetection.filterSet = true;
     activityDetection.config = *config;
     memset(&activityDetection.status, 0, sizeof(activityDetection.status));
   } else {
-    activityDetection.filter = NULL;
+    ntop->getTrace()->traceEvent(TRACE_WARNING, "[%s] Invalid activity filter ID: %u", this, fid);
   }
 }
 
 /* ***************************************************** */
 
 bool Flow::invokeActivityFilter(const struct timeval *when, bool cli2srv, u_int16_t payload_len) {
-  if (activityDetection.filter)
-    return (*activityDetection.filter)(&activityDetection.config, &activityDetection.status, this, when, cli2srv, payload_len);
+  if (activityDetection.filterSet)
+    return (activity_filter_funcs[activityDetection.filterId])(&activityDetection.config, &activityDetection.status, this, when, cli2srv, payload_len);
   return false;
 }

--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -50,6 +50,7 @@ static const char * activity_names [] = {
   "Chat",
   "Game",
   "RemoteControl",
+  "Facebook",
 };
 COMPILE_TIME_ASSERT (COUNT_OF(activity_names) == UserActivitiesN);
 
@@ -3750,6 +3751,7 @@ static int lua_flow_get_activity_filter_id(lua_State* vm) {
  *    minbytes     - minimum number of bytes to trigger activity
  *    maxinterval  - maximum milliseconds difference between packets
  *    serverdominant - if true, server bytes must be more then client bytes
+ *    forceWebProfile - if true, force 'web' profile for unknown and 'other' flow profiles
  *
  */
 static int lua_flow_set_activity_filter(lua_State* vm) {
@@ -3796,8 +3798,12 @@ static int lua_flow_set_activity_filter(lua_State* vm) {
           if (lua_type(vm, params+1) == LUA_TNUMBER) {
             config.web.maxinterval = lua_tonumber(vm, ++params);
 
-            if (lua_type(vm, params+1) == LUA_TBOOLEAN)
-              config.web.serverdominant = lua_toboolean(vm, ++params);
+            if (lua_type(vm, params+1) == LUA_TBOOLEAN) {
+              config.web.forceWebProfile = lua_toboolean(vm, ++params);
+
+              if (lua_type(vm, params+1) == LUA_TBOOLEAN)
+                config.web.serverdominant = lua_toboolean(vm, ++params);
+            }
           }
         }
       }
@@ -3806,7 +3812,8 @@ static int lua_flow_set_activity_filter(lua_State* vm) {
         case 2+0: config.web.numsamples = 4;
         case 2+1: config.web.minbytes = 0;
         case 2+2: config.web.maxinterval = 2000;
-        case 2+3: config.web.serverdominant = true;
+        case 2+3: config.web.forceWebProfile = true;
+        case 2+4: config.web.serverdominant = true;
       }
       break;
     case activity_filter_metrics_test:
@@ -4005,7 +4012,7 @@ int NetworkInterface::luaEvalFlow(Flow *f, const LuaCallback cb) {
   lua_State *L;
   const char *luaFunction;
 
-  //~ return(0); /* FIX */
+  return(0); /* FIX */
 
   if(reloadLuaInterpreter) {
     if(L_flow_create || L_flow_delete || L_flow_update) termLuaInterpreter();

--- a/src/UserActivityStats.cpp
+++ b/src/UserActivityStats.cpp
@@ -67,8 +67,8 @@ void UserActivityStats::deserialize(json_object *o) {
   while (!json_object_iter_equal(&it, &itEnd)) {
     char *key  = (char*)json_object_iter_peek_name(&it);
 
-    UserActivityID actid = getActivityId(key);
-    if (actid != user_activity_none) {
+    UserActivityID actid;
+    if (getActivityId(key, &actid)) {
       struct json_object* jobj = json_object_iter_peek_value(&it);
       struct json_object* value;
 


### PR DESCRIPTION
Changelog:
- Remove "App" activity
- Add separate "Facebook" activity
- Move SSL to "Other" activity by default, but allow "Web" filter to move it to "Web" activity
- Remove Yahoo protocol from "Chat" activity
- Fix default activity parameters (also causing all SMPTS traffic to be registered as background data)
- Add a "ratio" filter to exclude Facebook integration in websites from real "Facebook" activity
- Adjust some protocol activity detection parameters
- Remove "user_activity_none" from UserActivityID enum to be less error prone
