### PR TITLE
Use AC_CHECK_HEADER to test for hiredis

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -160,13 +160,15 @@ fi
 
 DATE=`date +"%Y-%m-%d"`
 
-if test -d "/usr/include/hiredis"; then
- AC_DEFINE_UNQUOTED(HAVE_HIREDIS, 1, [Local hiredis package present])
- HIREDIS_INC="`pkg-config --cflags hiredis` -I/usr/include/hiredis"
- HIREDIS_LIB="`pkg-config --libs hiredis` -lhiredis"
-else
- HIREDIS_INC="-I ${PWD}/third-party/hiredis"
-fi
+
+AC_CHECK_HEADER(hiredis/hiredis.h, [
+  AC_DEFINE_UNQUOTED(HAVE_HIREDIS, 1, [Local hiredis package present])
+  HIREDIS_INC="`pkg-config --cflags hiredis`"
+  HIREDIS_LIB="`pkg-config --libs hiredis` -lhiredis"
+],
+[
+  HIREDIS_INC="-I ${PWD}/third-party/hiredis"
+])
 
 PF_RING_HOME=${HOME}/PF_RING
 if test -d ${PF_RING_HOME}; then


### PR DESCRIPTION
Testing for /usr/include/hiredis is bad for cross compiles.

This commit fixes also the problem that -I/usr/include/hiredis
was added twice to HIREDIS_INC. Once manually and once through
pkg-config --clags.