### PR TITLE
Create a preference to enable top sites

### DIFF
--- a/include/Prefs.h
+++ b/include/Prefs.h
@@ -48,7 +48,8 @@ class Prefs {
     disable_alerts, enable_ixia_timestamps, enable_vss_apcon_timestamps,
     enable_users_login, disable_localhost_login, online_license_check,
     enable_idle_local_hosts_cache,  enable_active_local_hosts_cache,
-    enable_probing_alerts, enable_syslog_alerts, dump_flow_alerts_when_iface_alerted;
+    enable_probing_alerts, enable_syslog_alerts, dump_flow_alerts_when_iface_alerted,
+    enable_top_talkers;
   LocationPolicy dump_hosts_to_db, sticky_hosts;
   u_int non_local_host_max_idle, local_host_cache_duration, local_host_max_idle, flow_max_idle;
   u_int16_t intf_rrd_raw_days, intf_rrd_1min_days, intf_rrd_1h_days, intf_rrd_1d_days;
@@ -155,6 +156,7 @@ class Prefs {
   inline int   get_max_num_alerts_per_entity()          { return(max_num_alerts_per_entity); };
   inline int   get_max_num_flow_alerts()                { return(max_num_flow_alerts); };
   inline bool  are_alerts_disabled()                    { return(disable_alerts);     };
+  inline bool  are_top_talkers_enabled()                { return(enable_top_talkers);     };
   inline void  set_alerts_status(bool enabled)          { if(enabled) disable_alerts = false; else disable_alerts = true; };
   inline bool  are_probing_alerts_enabled()             { return(enable_probing_alerts);            };
   inline bool  are_alerts_syslog_enabled()              { return(enable_syslog_alerts);             };

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -120,6 +120,7 @@
 #define HOST_ACTIVITY_RRD_1H_DAYS    15
 #define HOST_ACTIVITY_RRD_1D_DAYS    90
 #define CONST_DEFAULT_IS_FLOW_ACTIVITY_ENABLED   false /* disabled by default */
+#define CONST_DEFAULT_TOP_TALKERS_ENABLED        false
 #define PURGE_FRACTION           32 /* check 1/32 of hashes per iteration */
 #define MAX_NUM_QUEUED_ADDRS    500 /* Maximum number of queued address for resolution */
 #define MAX_NUM_QUEUED_CONTACTS 25000
@@ -333,6 +334,7 @@
 #define CONST_SQL_BATCH_SIZE               32
 #define CONST_MAX_SQL_QUERY_LEN            8192
 #define CONST_ALERT_DISABLED_PREFS         "ntopng.prefs.disable_alerts_generation"
+#define CONST_TOP_TALKERS_ENABLED          "ntopng.prefs.host_top_sites_creation"
 #define CONST_ALERT_PREFS                  "ntopng.prefs.alerts"
 #ifdef NTOPNG_PRO
 #define CONST_NAGIOS_NSCA_HOST_PREFS       "ntopng.prefs.nagios_nsca_host"

--- a/scripts/lua/admin/prefs.lua
+++ b/scripts/lua/admin/prefs.lua
@@ -49,6 +49,7 @@ local menu_subpages = {
   {id="on_disk_rrds",  label="On-Disk Timeseries",   advanced=false, pro_only=false,  disabled=false},
   {id="on_disk_dbs",   label="On-Disk Databases",    advanced=true,  pro_only=false,  disabled=false},
   {id="alerts",        label="Alerts",               advanced=false, pro_only=false,  disabled=(prefs.has_cmdl_disable_alerts == true)},
+  {id="protocols",     label="Protocols",            advanced=false, pro_only=false,  disabled=false},
   {id="report",        label="Units of Measurement", advanced=false, pro_only=false,  disabled=false},
   {id="logging",       label="Log Level",            advanced=false, pro_only=false,  disabled=(prefs.has_cmdl_trace_lvl == true)},
   {id="nbox",          label="nBox Integration",     advanced=true,  pro_only=true,   disabled=false},
@@ -296,6 +297,28 @@ end
   end
 
   print('<tr><th colspan=2 style="text-align:right;"><button type="submit" class="btn btn-primary" style="width:115px">Save</button></th></tr>')
+  print('</table>')
+  print [[<input id="csrf" name="csrf" type="hidden" value="]] print(ntop.getRandomCSRFValue()) print [[" />
+  </form> ]]
+end
+
+-- ================================================================================
+
+function printProtocols()
+  print('<form method="post">')
+
+  print('<table class="table">')
+
+  print('<tr><th colspan=2 class="info">HTTP Settings</th></tr>')
+
+  toggleTableButtonPrefs("Top Sites",
+        "Toggle the creation of Top Sites timeseries. This may increase the disk usage.",
+        "On", "1", "success",
+        "Off", "0", "danger",
+        "toggle_top_sites", "ntopng.prefs.host_top_sites_creation", "0")
+
+  print('<tr><th colspan=2 style="text-align:right;"><button type="submit" class="btn btn-primary" style="width:115px">Save</button></th></tr>')
+
   print('</table>')
   print [[<input id="csrf" name="csrf" type="hidden" value="]] print(ntop.getRandomCSRFValue()) print [[" />
   </form> ]]
@@ -652,6 +675,9 @@ if (subpage_active == "on_disk_dbs") then
 end
 if (subpage_active == "alerts") then
    printAlerts()
+end
+if (subpage_active == "protocols") then
+   printProtocols()
 end
 if (subpage_active == "nbox") then
   if (ntop.isPro()) then

--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -59,6 +59,7 @@ Prefs::Prefs(Ntop *_ntop) {
   dns_mode = 0;
   logFd = NULL;
   disable_alerts = false;
+  enable_top_talkers = false;
   max_num_alerts_per_entity = ALERTS_MANAGER_MAX_ENTITY_ALERTS;
   max_num_flow_alerts = ALERTS_MANAGER_MAX_FLOW_ALERTS;
   pid_path = strdup(DEFAULT_PID_PATH);
@@ -421,6 +422,8 @@ void Prefs::reloadPrefsFromRedis() {
   // sets to the default value in redis if no key is found
   getDefaultPrefsValue(CONST_RUNTIME_IS_AUTOLOGOUT_ENABLED,
 		       CONST_DEFAULT_IS_AUTOLOGOUT_ENABLED);
+  enable_top_talkers		  = getDefaultPrefsValue(CONST_TOP_TALKERS_ENABLED,
+							 CONST_DEFAULT_TOP_TALKERS_ENABLED);
   enable_idle_local_hosts_cache   = getDefaultPrefsValue(CONST_RUNTIME_IDLE_LOCAL_HOSTS_CACHE_ENABLED,
 							 CONST_DEFAULT_IS_IDLE_LOCAL_HOSTS_CACHE_ENABLED);
   enable_active_local_hosts_cache = getDefaultPrefsValue(CONST_RUNTIME_ACTIVE_LOCAL_HOSTS_CACHE_ENABLED,
@@ -1177,6 +1180,7 @@ void Prefs::lua(lua_State* vm) {
   lua_push_bool_table_entry(vm, "is_httpbl_enabled", is_httpbl_enabled());
   lua_push_bool_table_entry(vm, "is_autologout_enabled", enable_auto_logout);
   lua_push_bool_table_entry(vm, "are_alerts_enabled", !disable_alerts);
+  lua_push_bool_table_entry(vm, "are_top_talkers_enabled", enable_top_talkers);
   lua_push_int_table_entry(vm, "http_port", http_port);
   lua_push_int_table_entry(vm, "local_host_max_idle", local_host_max_idle);
   lua_push_int_table_entry(vm, "local_host_cache_duration", local_host_cache_duration);
@@ -1307,6 +1311,10 @@ int Prefs::refresh(const char *pref_name, const char *pref_value) {
 		    (char*)CONST_ALERT_DISABLED_PREFS,
 		    strlen((char*)CONST_ALERT_DISABLED_PREFS)))
     disable_alerts = pref_value[0] == '1' ? true : false;
+  else if(!strncmp(pref_name,
+		    (char*)CONST_TOP_TALKERS_ENABLED,
+		    strlen((char*)CONST_TOP_TALKERS_ENABLED)))
+    enable_top_talkers = pref_value[0] == '1' ? true : false;
   else if(!strncmp(pref_name,
 		    (char*)CONST_RUNTIME_IDLE_LOCAL_HOSTS_CACHE_ENABLED,
 		    strlen((char*)CONST_RUNTIME_IDLE_LOCAL_HOSTS_CACHE_ENABLED)))


### PR DESCRIPTION
Calculating top sites in redis can be disk-intensive task for big networks.
This is now disabled by default and can be manually enabled from preferences page.