### PR TITLE
fixed small typo on webpage

### DIFF
--- a/scripts/lua/admin/prefs.lua
+++ b/scripts/lua/admin/prefs.lua
@@ -262,7 +262,7 @@ function printAlerts()
 		       "Set the username of the sender of slack notifications", "ntopng.alerts.", "sender_username",
 		       "ntopng Webhook", nil, showElements and showSlackNotificationPrefs, false, nil, {attributes={spellcheck="false"}})
 
-  prefsInputFieldPrefs("Notification Wekhook",
+  prefsInputFieldPrefs("Notification Webhook",
 		       "Send your notification to this slack URL", "ntopng.alerts.", "slack_webhook",
 		       "", nil, showElements and showSlackNotificationPrefs, true, true, {attributes={spellcheck="false"}})
 


### PR DESCRIPTION
there was a typo on the alerts configuration page
for slack notification.  Listed as "Notification Wekhook"
instead of "Notification Webhook"