### PR TITLE
Adjustments to obtain an OpenBSD build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,6 +1,7 @@
 @PRO_MAKEFILE_INC@
 prefix = @prefix@
 datadir = @datadir@
+datarootdir = @datarootdir@
 SHELL=/bin/sh
 OS := $(shell uname -s)
 PWD=@PWD@
@@ -49,7 +50,7 @@ else
 	endif
 endif
 ######
-ifeq ($(OS), $(filter $(OS), OpenBSD FreeBSD))
+ifeq ($(OS), $(filter $(OS), FreeBSD))
 	LIBNBPF_HOME=${PWD}/../PF_RING/userland/nbpf
 	LIBNBPF_LIB=$(LIBNBPF_HOME)/libnbpf.a
 endif

--- a/doc/README.OpenBSD
+++ b/doc/README.OpenBSD
@@ -1,0 +1,46 @@
+OpenBSD 5.9+ README
+-------------------
+
+A number of packages has to be installed to satisfy build dependencies.
+Let's start with GNU build tools:
+
+# pkg_add autoconf-2.69p2
+# pkg_add autogen-5.8.7p4
+# pkg_add automake-1.9.6p12
+# pkg_add gettext-0.19.7
+# pkg_add gmake-4.2.1
+# pkg_add libtool-2.4.2p0
+
+
+Then we have to install client libraries, llvm compiler, and of course git.
+
+# pkg_add wget
+# pkg_add json-c-0.12p1 mysqlcc GeoIP rrdtool llvm git
+
+
+git clone and build
+___________________
+
+$ cd /some/path
+$ git clone https://github.com/ntopng/ntopng.git
+$ cd ntopng
+$ git clone https://github.com/ntopng/nDPI.git
+
+$ AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.9 ./autogen.sh
+$ AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.9 ./configure
+$ gmake
+$ gmake geoip
+$ gmake install
+
+
+Redis server and first start
+____________________________
+
+Before you can launch ntopng, a Redis server has to be installed and started.
+
+# pkg_add redis
+
+Enable and start redis, which will listen on 631/TCP port.
+
+# rcctl enable redis
+# rcctl start redis

--- a/include/Flow.h
+++ b/include/Flow.h
@@ -262,7 +262,7 @@ class Flow : public GenericHashEntry {
   bool isFlowPeer(char *numIP, u_int16_t vlanId);
   void incStats(bool cli2srv_direction, u_int pkt_len,
 		u_int8_t *payload, u_int payload_len, u_int8_t l4_proto,
-		const struct bpf_timeval *when);
+		const struct timeval *when);
   void updateActivities();
   void addFlowStats(bool cli2srv_direction, u_int in_pkts, u_int in_bytes, u_int in_goodput_bytes,
 		    u_int out_pkts, u_int out_bytes, u_int out_goodput_bytes, time_t last_seen);

--- a/src/DivertInterface.cpp
+++ b/src/DivertInterface.cpp
@@ -58,8 +58,15 @@ static void* divertPacketPollLoop(void* ptr) {
       ntop->getTrace()->traceEvent(TRACE_ERROR, "Packet too short (%d bytes)", len);
       break;
     }
-   
+  
+#ifdef __OpenBSD__
+    struct timeval tv;
+    h.len = h.caplen = len, gettimeofday(&tv, NULL);
+    h.ts.tv_sec  = tv.tv_sec;
+    h.ts.tv_usec = tv.tv_usec;
+#else
     h.len = h.caplen = len, gettimeofday(&h.ts, NULL);
+#endif /* __OpenBSD__ */
     iface->dissectPacket(&h, packet, &c, &srcHost, &dstHost, &flow);
 
     /* Enable the row below to specify the firewall rule corresponding to the protocol */

--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -1191,7 +1191,14 @@ bool NetworkInterface::processPacket(const struct bpf_timeval *when,
       break;
     }
 
+#ifdef __OpenBSD__
+    struct timeval tv_ts;
+    tv_ts.tv_sec  = h->ts.tv_sec;
+    tv_ts.tv_usec = h->ts.tv_usec;
+    flow->incStats(src2dst_direction, rawsize, payload, payload_len, l4_proto, &tv_ts);
+#else
     flow->incStats(src2dst_direction, rawsize, payload, payload_len, l4_proto, &h->ts);
+#endif
   }
 
   /* Protocol Detection */
@@ -1382,7 +1389,14 @@ bool NetworkInterface::processPacket(const struct bpf_timeval *when,
       u_int64_t up = 0, down = 0, backgr = 0, bytes = payload_len;
 
       if(flow->getActivityId(&activity)) {
+#ifdef __OpenBSD__
+        struct timeval* tv_when;
+        tv_when->tv_sec  = when->tv_sec;
+        tv_when->tv_usec = when->tv_usec;
+        if(flow->invokeActivityFilter(tv_when, src2dst_direction, payload_len)) {
+#else 
         if(flow->invokeActivityFilter(when, src2dst_direction, payload_len)) {
+#endif
           if(src2dst_direction)
             up = bytes;
           else


### PR DESCRIPTION
Attempting to build OpenBSD fails for various reasons.

First and foremost, there is a number of packages that have to
be installed as build dependencies

Then, small updates are needed to the autotools files to have autogen.sh
and configure, to exit without errors.

doc/README.OpenBSD describes the whole process in fair detail.

Last but not least, there are type errors that g++ compiler catches in
OpenBSD but not in Linux. To have the build, a few source files
were updated to have effect only in OpenBSD, leaving other operating
systems untouched.

With only one exception, a prototype in include/Flow.h was updated to
stay in sync with the implementation.