### PR TITLE
Logstash flow export extension

### DIFF
--- a/include/Logstash.h
+++ b/include/Logstash.h
@@ -1,0 +1,57 @@
+/*
+ *
+ * (C) 2013-17 - ntop.org
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#ifndef _LOGSTASH_H_
+#define _LOGSTASH_H_
+
+#include "ntop_includes.h"
+
+class Logstash {
+ private:
+  pthread_t lsThreadLoop;
+  u_int num_queued_elems;
+  struct string_list *head, *tail;
+  pthread_rwlock_t listMutex;
+  bool reportDrops;
+  struct timeval lastUpdateTime;
+  u_int32_t elkDroppedFlowsQueueTooLong;
+  u_int64_t elkExportedFlows, elkLastExportedFlows;
+  float elkExportRate;
+  u_int64_t checkpointDroppedFlows, checkpointExportedFlows; /* Those will hold counters at checkpoints */
+ public:
+  Logstash();
+  ~Logstash();
+  void checkPointCounters(bool drops_only) {
+    if(!drops_only)
+      checkpointExportedFlows = elkExportedFlows;
+    checkpointDroppedFlows = elkDroppedFlowsQueueTooLong;
+  };
+  inline u_int32_t numDroppedFlows() const { return elkDroppedFlowsQueueTooLong; };
+  int sendToLS(char* msg);
+  void sendLSdata();
+  void startFlowDump();
+
+  void updateStats(const struct timeval *tv);
+  void lua(lua_State* vm, bool since_last_checkpoint) const;
+};
+
+
+#endif /* _LOGSTASH_H_ */

--- a/include/NetworkInterface.h
+++ b/include/NetworkInterface.h
@@ -235,6 +235,7 @@ class NetworkInterface {
   int dumpFlow(time_t when, bool idle_flow, Flow *f);
   int dumpDBFlow(time_t when, bool idle_flow, Flow *f);
   int dumpEsFlow(time_t when, Flow *f);
+  int dumpLsFlow(time_t when, Flow *f);
   int dumpLocalHosts2redis(bool disable_purge);
   inline void incRetransmittedPkts(u_int32_t num)   { tcpPacketStats.incRetr(num); };
   inline void incOOOPkts(u_int32_t num)             { tcpPacketStats.incOOO(num);  };

--- a/include/Ntop.h
+++ b/include/Ntop.h
@@ -52,6 +52,7 @@ class Ntop {
   u_int num_cpus; /**< Number of physical CPU cores. */
   Redis *redis; /**< Pointer of Redis server. */
   ElasticSearch *elastic_search; /**< Pointer of Elastic Search. */
+  Logstash *logstash; /**< Pointer of Logstash. */
   PeriodicActivities *pa; /**< Instance of periodical activities. */
   AddressResolution *address;
   Prefs *prefs;
@@ -363,6 +364,7 @@ class Ntop {
   inline Trace*            getTrace()                { return(globals->getTrace()); };
   inline Redis*            getRedis()                { return(redis);               };
   inline ElasticSearch*    getElasticSearch()        { return(elastic_search);      };
+  inline Logstash*         getLogstash()             { return(logstash);            };
   inline Prefs*            getPrefs()                { return(prefs);               };
   inline RuntimePrefs*     getRuntimePrefs()         { return(runtimeprefs);        };
   inline ExportInterface*  get_export_interface()    { return(export_interface);    };
@@ -405,6 +407,7 @@ class Ntop {
   void createExportInterface();
   void initRedis();
   void initElasticSearch();
+  void initLogstash(); 
 
   inline u_int32_t getStarttime()        { return((u_int32_t)start_time); }
   inline char*     getStarttimeString()  { return(epoch_buf);             }

--- a/include/Prefs.h
+++ b/include/Prefs.h
@@ -61,7 +61,7 @@ class Prefs {
   u_int32_t max_num_hosts, max_num_flows;
   u_int http_port, alt_http_port, https_port;
   u_int8_t num_interfaces;
-  bool dump_flows_on_es, dump_flows_on_mysql;
+  bool dump_flows_on_es, dump_flows_on_mysql,dump_flows_on_ls;
   bool enable_taps;
   InterfaceInfo ifNames[MAX_NUM_INTERFACES];
   char *local_networks;
@@ -87,6 +87,7 @@ class Prefs {
   FILE *logFd;
   char *es_type, *es_index, *es_url, *es_user, *es_pwd;
   char *mysql_host, *mysql_dbname, *mysql_tablename, *mysql_user, *mysql_pw;
+  char *ls_host,*ls_port,*ls_proto;
   bool has_cmdl_trace_lvl;	/**< Indicate whether a verbose level has been provided on the command line.*/
   bool has_cmdl_disable_alerts;	/**< Indicate whether alerts were forcefully disabled from the command line */
   int max_num_alerts_per_entity, max_num_flow_alerts;
@@ -145,6 +146,7 @@ class Prefs {
   inline u_int8_t get_num_user_specified_interfaces()   { return(num_interfaces);         };
   inline bool  do_dump_flows_on_es()                    { return(dump_flows_on_es);       };
   inline bool  do_dump_flows_on_mysql()                 { return(dump_flows_on_mysql);    };
+  inline bool  do_dump_flows_on_ls()                    { return(dump_flows_on_ls);       };
   u_int32_t getDefaultPrefsValue(const char *pref_key, u_int32_t default_value);
   void getDefaultStringPrefsValue(const char *pref_key, char **buffer, const char *default_value);
   inline char* get_if_name(u_int id)                    { return((id < MAX_NUM_INTERFACES) ? ifNames[id].name : NULL); };
@@ -221,6 +223,9 @@ class Prefs {
   inline char* get_mysql_tablename()    { return(mysql_tablename);       };
   inline char* get_mysql_user()         { return(mysql_user);            };
   inline char* get_mysql_pw()           { return(mysql_pw);              };
+  inline char* get_ls_host()            { return(ls_host);               };
+  inline char* get_ls_port()		{ return(ls_port);		 };
+  inline char* get_ls_proto()		{ return(ls_proto);		 };
   inline char* get_zmq_encryption_pwd() { return(zmq_encryption_pwd);    };
   inline char* get_command_line()       { return(cli ? cli : (char*)""); };
   inline char* getInterfaceAt(int id)     { return((id >= MAX_NUM_INTERFACES) ? NULL : ifNames[id].name); }

--- a/include/Redis.h
+++ b/include/Redis.h
@@ -42,6 +42,7 @@ class Redis {
   u_int16_t redis_port;
   u_int8_t redis_db_id;
   pthread_t esThreadLoop;
+  pthread_t lsThreadLoop;
   bool operational;
   StringCache_t *stringCache;
   u_int numCached;

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -627,6 +627,8 @@
 #define NTOP_ES_TEMPLATE              "ntopng_template_elk.json"
 #define ES_MAX_QUEUE_LEN              32768
 
+/* Logstash */
+#define LS_MAX_QUEUE_LEN              32768
 /* Unknown values for host groups */
 #define UNKNOWN_COUNTRY       ""
 #define UNKNOWN_OS            ""

--- a/include/ntop_includes.h
+++ b/include/ntop_includes.h
@@ -194,6 +194,7 @@ using namespace std;
 #include "HTTPstats.h"
 #include "Redis.h"
 #include "ElasticSearch.h"
+#include "Logstash.h"
 #include "StoreManager.h"
 #include "StatsManager.h"
 #include "AlertsManager.h"

--- a/scripts/lua/if_stats.lua
+++ b/scripts/lua/if_stats.lua
@@ -454,7 +454,10 @@ print("</script>\n")
    if(ifstats.stats.drops > 0) then print('<span class="label label-danger">') end
    print(formatValue(ifstats.stats.drops).. " " .. label)
 
-   if((ifstats.stats.packets+ifstats.stats.drops) > 0) then
+   if ifstats.stats.packets == null or ifstats.stats.drops == null then
+
+   
+   elseif((ifstats.stats.packets+ifstats.stats.drops) > 0) then
       local pctg = round((ifstats.stats.drops*100)/(ifstats.stats.packets+ifstats.stats.drops), 2)
       if(pctg > 0) then print(" [ " .. pctg .. " % ] ") end
    end
@@ -476,12 +479,17 @@ print("</script>\n")
       if prefs.is_dump_flows_to_es_enabled == true then
 	 dump_to = "ElasticSearch"
       end
+      if prefs.is_dump_flows_to_ls_enabled == true then
+	 dump_to = "Logstash"
+      end
 
       local export_count     = ifstats.stats.flow_export_count
       local export_rate      = ifstats.stats.flow_export_rate
       local export_drops     = ifstats.stats.flow_export_drops
       local export_drops_pct = 0
-      if export_drops > 0 and export_count > 0 then
+      if export_drops == nill then 
+
+      elseif export_drops > 0 and export_count > 0 then
 	 export_drops_pct = export_drops / export_count * 100
       end
 
@@ -490,10 +498,16 @@ print("</script>\n")
       print("<tr>")
       print("<th nowrap>Exported Flows</th>")
       print("<td><span id=exported_flows>"..formatValue(export_count).."</span>")
+      if export_rate == nil then
+	export_rate = 0
+      end
       print("&nbsp;[<span id=exported_flows_rate>"..formatValue(round(export_rate, 2)).."</span> Flows/s]</td>")
       print("<th>Dropped Flows</th>")
       local span_danger = ""
-      if(export_drops > 0) then
+      if export_drops == nil then 
+
+     
+      elseif(export_drops > 0) then
 	 span_danger = ' class="label label-danger"'
       end
       print("<td><span id=exported_flows_drops "..span_danger..">"..formatValue(export_drops).."</span>&nbsp;")

--- a/scripts/lua/modules/lua_utils.lua
+++ b/scripts/lua/modules/lua_utils.lua
@@ -486,7 +486,7 @@ end
 --   print(_key .. "=" .. _value .. "\n")
 --end
 
-function round(num, idp) return tonumber(string.format("%." .. (idp or 0) .. "f", num)) end
+function round(num, idp)         return tonumber(string.format("%." .. (idp or 0) .. "f", num)) end
 --function round(num) return math.floor(num+.5) end
 
 -- Note that the function below returns a string as returning a number

--- a/scripts/lua/network_load.lua
+++ b/scripts/lua/network_load.lua
@@ -35,7 +35,8 @@ function dumpInterfaceStats(interface_name)
       res["drops"]   = ifstats.stats_since_reset.drops
       
       if prefs.is_dump_flows_to_es_enabled == true
-       or prefs.is_dump_flows_to_mysql_enabled == true then
+       or prefs.is_dump_flows_to_mysql_enabled == true 
+	or prefs.is_dump_flows_to_ls_enabled then
 	  res["flow_export_drops"]  = ifstats.stats_since_reset.flow_export_drops
 	  res["flow_export_rate"]   = ifstats.stats_since_reset.flow_export_rate
 	  res["flow_export_count"]  = ifstats.stats_since_reset.flow_export_count

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -804,6 +804,7 @@ bool Flow::dumpFlow(bool idle_flow) {
 
   if(ntop->getPrefs()->do_dump_flows_on_mysql()
      || ntop->getPrefs()->do_dump_flows_on_es()
+     || ntop->getPrefs()->do_dump_flows_on_ls()
      || ntop->get_export_interface()) {
 #ifdef NTOPNG_PRO
     if(!detection_completed || cli2srv_packets + srv2cli_packets <= NDPI_MIN_NUM_PACKETS)
@@ -826,6 +827,8 @@ bool Flow::dumpFlow(bool idle_flow) {
 	cli_host->getInterface()->dumpDBFlow(last_seen, idle_flow, this);
       else if(ntop->getPrefs()->do_dump_flows_on_es())
 	cli_host->getInterface()->dumpEsFlow(last_seen, this);
+      else if(ntop->getPrefs()->do_dump_flows_on_ls())
+        cli_host->getInterface()->dumpLsFlow(last_seen, this);
     }
 
     if(ntop->get_export_interface()) {

--- a/src/Logstash.cpp
+++ b/src/Logstash.cpp
@@ -1,0 +1,235 @@
+/*
+ *
+ * (C) 2013-17 - ntop.org
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "ntop_includes.h"
+
+/* **************************************************** */
+
+static void* lsLoop(void* ptr) {
+  ntop->getLogstash()->sendLSdata();
+  return(NULL);
+}
+
+/* **************************************** */
+
+
+
+Logstash::Logstash() {
+  pthread_rwlock_init(&listMutex, NULL);
+  num_queued_elems = 0;
+  head = NULL;
+  tail = NULL;
+  reportDrops = false;
+  checkpointDroppedFlows = checkpointExportedFlows = 0;
+  lastUpdateTime.tv_sec = 0, lastUpdateTime.tv_usec = 0;
+}
+
+/* **************************************** */
+
+Logstash::~Logstash(){
+
+}
+
+/* ******************************************* */
+
+void Logstash::updateStats(const struct timeval *tv) {
+  if(tv == NULL) return;
+
+  if(lastUpdateTime.tv_sec > 0) {
+    float tdiffMsec = ((float)(tv->tv_sec-lastUpdateTime.tv_sec)*1000)+((tv->tv_usec-lastUpdateTime.tv_usec)/(float)1000);
+    if(tdiffMsec >= 1000) { /* al least one second */
+      u_int64_t diffFlows = elkExportedFlows - elkLastExportedFlows;
+      elkLastExportedFlows = elkExportedFlows;
+
+      elkExportRate = ((float)(diffFlows * 1000)) / tdiffMsec;
+      if (elkExportRate < 0) elkExportRate = 0;
+    }
+  }
+
+  memcpy(&lastUpdateTime, tv, sizeof(struct timeval));
+}
+
+/* ******************************************* */
+
+void Logstash::lua(lua_State *vm, bool since_last_checkpoint) const {
+  lua_push_int_table_entry(vm,   "flow_export_count",
+			   elkExportedFlows - (since_last_checkpoint ? checkpointExportedFlows : 0));
+  lua_push_int32_table_entry(vm, "flow_export_drops",
+			     elkDroppedFlowsQueueTooLong - (since_last_checkpoint ? checkpointDroppedFlows : 0));
+  lua_push_float_table_entry(vm, "flow_export_rate",
+			     elkExportRate >= 0 ? elkExportRate : 0);
+}
+
+/* **************************************** */
+
+int Logstash::sendToLS(char* msg) {
+  struct string_list *e;
+  int rc = 0;
+
+  if(!strcmp(msg,"")){
+    return (-1);
+  }
+  if(num_queued_elems >= LS_MAX_QUEUE_LEN) {
+    if(!reportDrops) {
+      ntop->getTrace()->traceEvent(TRACE_WARNING, "[LS] Export queue too long [%d]: expect drops",
+		 num_queued_elems);
+      reportDrops = true;
+    }
+
+    elkDroppedFlowsQueueTooLong++;
+    ntop->getTrace()->traceEvent(TRACE_INFO, "[LS] Message dropped. Total messages dropped: %lu\n",
+		 elkDroppedFlowsQueueTooLong);
+
+    return(-1);
+  }
+
+  pthread_rwlock_wrlock(&listMutex);
+  e = (struct string_list*)calloc(1, sizeof(struct string_list));
+  if( e != NULL) {
+    e->str = strdup(msg), e->next = head;
+
+    if(e->str) {
+      if(head)
+        head->prev = e;
+      head = e;
+      if(tail == NULL)
+	tail = e;
+      num_queued_elems++;
+
+      rc = 0;
+    } else {
+      /* Out of memory */
+      free(e);
+      rc = -1;
+    }
+  }
+
+  pthread_rwlock_unlock(&listMutex);
+  return rc;
+}
+
+/* **************************************** */
+
+void Logstash::startFlowDump() {
+  if(ntop->getPrefs()->do_dump_flows_on_ls()){
+    pthread_create(&lsThreadLoop, NULL, lsLoop, (void*)this);
+  }
+}
+
+
+/* **************************************** */
+
+void Logstash::sendLSdata() {
+  const u_int watermark = 8, min_buf_size = 512;
+  char postbuf[16384];
+  while(!ntop->getGlobals()->isShutdown()) {
+
+    if(num_queued_elems >= watermark) {
+      u_int len, num_flows;
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+
+      len = 0, num_flows = 0;
+
+      pthread_rwlock_wrlock(&listMutex);
+      for(u_int i=0; (i<watermark) && ((sizeof(postbuf)-len) > min_buf_size); i++) {
+        struct string_list *prev;
+        prev = tail->prev;
+	len += snprintf(&postbuf[len], sizeof(postbuf)-len, "%s\n", tail->str), num_flows++;
+        free(tail->str);
+        free(tail);
+        tail = prev,
+	num_queued_elems--;
+        if(num_queued_elems == 0)
+	  head = NULL;
+
+      } /* for */
+
+      pthread_rwlock_unlock(&listMutex);
+      postbuf[len] = '\0';
+
+	if(postbuf[0]!='{'){
+		sleep(1);continue;
+	}
+
+        char *proto; 
+	proto = ntop->getPrefs()->get_ls_proto();
+
+	int sockfd;
+
+	if(!strncmp(proto,"udp",3)){
+	  //UDP socket
+	  sockfd = socket(AF_INET,SOCK_DGRAM, IPPROTO_UDP);
+	}else{
+	  //TCP socket 
+	  sockfd = socket(AF_INET, SOCK_STREAM, 0);
+        }
+	struct hostent *server;
+	server = gethostbyname(ntop->getPrefs()->get_ls_host());
+	char *portstr = ntop->getPrefs()->get_ls_port();
+
+	int portno;
+	if(portstr == NULL){
+		portno = 5510;
+	}else{
+		portno = atoi(portstr);
+	}
+	struct sockaddr_in serv_addr;
+
+	
+      if(sockfd < 0 || server == NULL) {
+	/* Post failure */
+	sleep(1);
+      } else {
+	bzero((char *) &serv_addr,sizeof(serv_addr));
+	serv_addr.sin_family = AF_INET;
+	bcopy((char *) server->h_addr, (char *)&serv_addr.sin_addr.s_addr, server->h_length);
+	serv_addr.sin_port = htons(portno);
+
+	if(!strncmp(proto,"tcp",3)&&connect(sockfd,(struct sockaddr *)&serv_addr,sizeof(serv_addr)) <0) {
+	  sleep(1);
+	}else {
+	  
+	  if(
+             (!strncmp(proto,"tcp",3)&&send(sockfd,postbuf,sizeof(postbuf),0)<0)
+	      || 
+	      (
+                !strncmp(proto,"udp",3)
+                &&
+                sendto(sockfd,postbuf,sizeof(postbuf),0,(struct sockaddr *)&serv_addr,sizeof(serv_addr))<0
+              )
+	    ){
+	    sleep(1);
+	  }else{
+	    elkExportedFlows += num_flows;
+	  }
+
+	}
+      }
+    } else
+      sleep(1);
+
+  } /* while */
+
+}
+
+
+

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -54,6 +54,7 @@ Ntop::Ntop(char *appName) {
   custom_ndpi_protos = NULL;
   prefs = NULL, redis = NULL;
   elastic_search = NULL;
+  logstash = NULL;
   num_cpus = -1;
   num_defined_interfaces = 0;
   export_interface = NULL;
@@ -167,7 +168,7 @@ Ntop::~Ntop() {
 
   if(custom_ndpi_protos)  delete(custom_ndpi_protos);
   if(elastic_search)      delete(elastic_search);
-
+  if(logstash)            delete(logstash);
   if(hostBlacklist)       delete hostBlacklist;
   if(hostBlacklistShadow) delete hostBlacklistShadow;
 
@@ -230,7 +231,7 @@ void Ntop::registerPrefs(Prefs *_prefs, bool quick_registration) {
   }
 
   initElasticSearch();
-
+  initLogstash();
 #ifdef NTOPNG_PRO
   if(((ntop->getPrefs()->get_http_port() != 80) && (ntop->getPrefs()->get_alt_http_port() != 80))
      || ((ntop->getPrefs()->get_http_port() == 80) && (ntop->getPrefs()->get_alt_http_port() == 0))) {
@@ -261,6 +262,10 @@ void Ntop::initRedis() {
 }
 
 /* ******************************************* */
+void Ntop::initLogstash(){
+  if(logstash) delete(logstash);
+  logstash = new Logstash();
+}
 
 void Ntop::initElasticSearch() {
   if(elastic_search) delete(elastic_search);
@@ -1432,6 +1437,11 @@ void Ntop::runHousekeepingTasks() {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     ntop->getElasticSearch()->updateStats(&tv);
+  }
+  if(ntop->getPrefs()->do_dump_flows_on_ls()){
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    ntop->getLogstash()->updateStats(&tv);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -229,6 +229,7 @@ int main(int argc, char *argv[])
   ntop->createExportInterface();
 
   ntop->getElasticSearch()->startFlowDump();
+  ntop->getLogstash()->startFlowDump();
 
   if(ntop->getInterfaceAtId(0) == NULL) {
     ntop->getTrace()->traceEvent(TRACE_ERROR, "Startup error: missing super-user privileges ?");


### PR DESCRIPTION
Extended flow export based on ES export to support sending data
to Logstash on TCP/UDP inputs.

eg. usage 
ntopng -F 'logstash;&lt;host&gt;;&lt;proto&gt;;&lt;port&gt;'

logstash config example


input {
   tcp {
      port => 5510
      type => "ntopng"
   }
}

filter {
  if "" not in [IPV4_SRC_ADDR] {
      drop {} 
  }
}

output {
 ...
}