### PR TITLE
Prevent assigning a network to the multiple Host Pools

### DIFF
--- a/include/HostPools.h
+++ b/include/HostPools.h
@@ -26,6 +26,7 @@
 
 class NetworkInterface;
 class Host;
+class Mac;
 #ifdef NTOPNG_PRO
 
 typedef struct {
@@ -76,6 +77,19 @@ public:
   virtual ~HostPools();
   void reloadPools();
   u_int16_t getPool(Host *h);
+
+  bool findIpNode(IpAddress *ip, u_int16_t vlan_id, patricia_node_t **found_node);
+  bool findMacPool(Mac *mac, u_int16_t *found_pool);
+  inline bool findIpPool(IpAddress *ip, u_int16_t vlan_id, u_int16_t *found_pool) {
+    patricia_node_t *node;
+
+    if (findIpNode(ip, vlan_id, &node)) {
+      *found_pool = node->user_data;
+      return true;
+    } else
+      return false;
+  }
+
 #ifdef NTOPNG_PRO
   void incPoolStats(u_int32_t when, u_int16_t host_pool_id, u_int16_t ndpi_proto,
 		    ndpi_protocol_category_t category_id, u_int64_t sent_packets, u_int64_t sent_bytes,

--- a/include/HostPools.h
+++ b/include/HostPools.h
@@ -78,17 +78,8 @@ public:
   void reloadPools();
   u_int16_t getPool(Host *h);
 
-  bool findIpNode(IpAddress *ip, u_int16_t vlan_id, patricia_node_t **found_node);
+  bool findIpPool(IpAddress *ip, u_int16_t vlan_id, u_int16_t *found_pool, patricia_node_t **found_node);
   bool findMacPool(Mac *mac, u_int16_t *found_pool);
-  inline bool findIpPool(IpAddress *ip, u_int16_t vlan_id, u_int16_t *found_pool) {
-    patricia_node_t *node;
-
-    if (findIpNode(ip, vlan_id, &node)) {
-      *found_pool = node->user_data;
-      return true;
-    } else
-      return false;
-  }
 
 #ifdef NTOPNG_PRO
   void incPoolStats(u_int32_t when, u_int16_t host_pool_id, u_int16_t ndpi_proto,

--- a/scripts/locales/en.lua
+++ b/scripts/locales/en.lua
@@ -340,7 +340,7 @@ local  en = {
       from_pool = "from host pool",
       and_associated_members = "its RRD data and any associated members",
       search_member = "Search Member",
-      network_normalized = "network \"%{network}\" has been normalized to \"%{network_normalized}\".",
+      network_normalized = "network \"%{network}\" has a non-zero host identifier. Using \"%{network_normalized}\".",
       member_exists = "member \"%{member_name}\" not added. It is already assigned to pool \"%{member_pool}\".",
    },
 

--- a/scripts/locales/en.lua
+++ b/scripts/locales/en.lua
@@ -2,6 +2,7 @@ local  en = {
    welcome = "Welcome",
    version = "Your version is %{vers}.",
    error = "Error",
+   warning = "Warning",
    host = "Host %{host}",
    hour = "Hour",
    day = "Day",
@@ -339,6 +340,8 @@ local  en = {
       from_pool = "from host pool",
       and_associated_members = "its RRD data and any associated members",
       search_member = "Search Member",
+      network_normalized = "network \"%{network}\" has been normalized and added to the pool as \"%{network_normalized}\".",
+      member_exists = "member \"%{member_name}\" not added. It is already assigned to pool \"%{member_pool}\".",
    },
 
    snmp = {

--- a/scripts/locales/en.lua
+++ b/scripts/locales/en.lua
@@ -340,7 +340,7 @@ local  en = {
       from_pool = "from host pool",
       and_associated_members = "its RRD data and any associated members",
       search_member = "Search Member",
-      network_normalized = "network \"%{network}\" has been normalized and added to the pool as \"%{network_normalized}\".",
+      network_normalized = "network \"%{network}\" has been normalized to \"%{network_normalized}\".",
       member_exists = "member \"%{member_name}\" not added. It is already assigned to pool \"%{member_pool}\".",
    },
 

--- a/scripts/lua/admin/host_pools.lua
+++ b/scripts/lua/admin/host_pools.lua
@@ -164,12 +164,8 @@ if selected_pool == nil then
   end
 end
 
-local perPageMembers
-if tonumber(tablePreferences("hostPoolMembers")) == nil then
-  perPageMembers = "10"
-else
-  perPageMembers = tablePreferences("hostPoolMembers")
-end
+-- We are passing too much _POST data, no more than 5 members allowed
+local perPageMembers = "5"
 
 local member_filtering = _GET["member"]
 local manage_url = "?ifid="..ifId.."&page=pools&pool="..selected_pool.id.."#manage"
@@ -483,6 +479,7 @@ print [[
       title: "",
       perPage: ]] print(perPageMembers) print[[,
       forceTable: true,
+      hidePerPage: true,
       
       buttons: [
          '<a id="addPoolMemberBtn" onclick="addPoolMember()" role="button" class="add-on btn" data-toggle="modal"><i class="fa fa-plus" aria-hidden="true"></i></a>'

--- a/scripts/lua/host_details.lua
+++ b/scripts/lua/host_details.lua
@@ -74,7 +74,7 @@ end
 
 only_historical = false
 
-local host_pool_id
+local host_pool_id = nil
 
 if (host ~= nil) then
    if (isAdministrator() and (_POST["pool"] ~= nil)) then
@@ -83,12 +83,17 @@ if (host ~= nil) then
 
       if host_pool_id ~= prev_pool then
          local key = host2member(host["ip"], host["vlan"])
-         host_pools_utils.deletePoolMember(ifId, prev_pool, key)
-         host_pools_utils.addPoolMember(ifId, host_pool_id, key)
-         interface.reloadHostPools()
+         if not host_pools_utils.changeMemberPool(ifId, key, prev_pool, host_pool_id) then
+            host_pool_id = nil
+         else
+            interface.reloadHostPools()
+         end
       end
-   else
-     host_pool_id = tostring(host["host_pool_id"])
+
+   end
+
+   if (host_pool_id == nil) then
+      host_pool_id = tostring(host["host_pool_id"])
    end
 end
 

--- a/scripts/lua/modules/host_pools_utils.lua
+++ b/scripts/lua/modules/host_pools_utils.lua
@@ -80,9 +80,8 @@ function getMembershipInfo(member_and_vlan)
   -- This is the normalized key, which should always be used to refer to the member
   local key = addr
   if not is_mac then
-    key = key.."/"..mask
+    key = key.."/"..mask.."@"..vlan
   end
-  key = key.."@"..vlan
 
   local info = {key=key}
   local exists = false

--- a/scripts/lua/modules/host_pools_utils.lua
+++ b/scripts/lua/modules/host_pools_utils.lua
@@ -78,9 +78,11 @@ function getMembershipInfo(member_and_vlan)
   local find_info = interface.findMemberPool(addr, vlan, is_mac)
 
   -- This is the normalized key, which should always be used to refer to the member
-  local key = addr
+  local key
   if not is_mac then
-    key = key.."/"..mask.."@"..vlan
+    key = host2member(addr, vlan, mask)
+  else
+    key = addr
   end
 
   local info = {key=key}

--- a/scripts/lua/modules/host_pools_utils.lua
+++ b/scripts/lua/modules/host_pools_utils.lua
@@ -64,10 +64,71 @@ function host_pools_utils.deletePool(ifid, pool_id)
   ntop.rmdir(rrd_base)
 end
 
+function getMembershipInfo(member_and_vlan)
+  -- Check if the member is already in another pool
+  local hostinfo = hostkey2hostinfo(member_and_vlan)
+  local addr, mask = splitNetworkPrefix(hostinfo["host"])
+  local vlan = hostinfo["vlan"]
+  local is_mac = isMacAddress(addr)
+
+  if not is_mac then
+    addr = ntop.networkPrefix(addr, mask)
+  end
+
+  local find_info = interface.findMemberPool(addr, vlan, is_mac)
+
+  -- This is the normalized key, which should always be used to refer to the member
+  local key = addr
+  if not is_mac then
+    key = key.."/"..mask
+  end
+  key = key.."@"..vlan
+
+  local info = {key=key}
+  local exists = false
+
+  if find_info ~= nil then
+    -- The host has been found
+    if is_mac or ((not is_mac)
+                  and (find_info.matched_prefix == addr)
+                  and (find_info.matched_bitmask == mask)) then
+      info["existing_member_pool"] = find_info.pool_id
+      exists = true
+    end
+  end
+
+  return exists, info
+end
+
+function host_pools_utils.changeMemberPool(ifid, member_and_vlan, prev_pool, new_pool)
+  if prev_pool == new_pool then return false end
+
+  local members_key = get_pool_members_key(ifid, new_pool)
+  local member_exists, info = getMembershipInfo(member_and_vlan)
+
+  if member_exists then
+    -- use the normalized key
+    member_and_vlan = info.key
+  elseif prev_pool ~= host_pools_utils.DEFAULT_POOL_ID then
+    -- member not found
+    return false
+  end
+
+  host_pools_utils.deletePoolMember(ifid, prev_pool, info.key)
+  ntop.setMembersCache(members_key, info.key)
+  return true
+end
+
 function host_pools_utils.addPoolMember(ifid, pool_id, member_and_vlan)
   local members_key = get_pool_members_key(ifid, pool_id)
+  local member_exists, info = getMembershipInfo(member_and_vlan)
 
-  ntop.setMembersCache(members_key, member_and_vlan)
+  if member_exists then
+    return false, info
+  else
+    ntop.setMembersCache(members_key, info.key)
+    return true, info
+  end
 end
 
 function host_pools_utils.deletePoolMember(ifid, pool_id, member_and_vlan)

--- a/scripts/lua/modules/http_lint.lua
+++ b/scripts/lua/modules/http_lint.lua
@@ -933,7 +933,7 @@ local function lintParams()
 
    for _,id in pairs(params_to_validate) do
       for k,v in pairs(id) do
-         if(debug) then io.write("[LINT] Validating ["..k.."]["..p[k].."]\n") end
+         if(debug) then io.write("[LINT] Validating ["..k.."]["..v.."]\n") end
 
          if enableValidation then
             if ((v == "") and

--- a/scripts/lua/modules/lua_utils.lua
+++ b/scripts/lua/modules/lua_utils.lua
@@ -1038,13 +1038,13 @@ function isValidPoolMember(member)
   return false
 end
 
-function host2member(ip, vlan)
-  local prefix
-
-  if isIPv4(ip) then
-    prefix = 32
-  else
-    prefix = 128
+function host2member(ip, vlan, prefix)
+  if prefix == nil then
+    if isIPv4(ip) then
+      prefix = 32
+    else
+      prefix = 128
+    end
   end
 
   return ip .. "/" .. tostring(prefix) .. "@" .. tostring(vlan)

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -627,7 +627,7 @@ bool HostPools::findMacPool(Mac *mac, u_int16_t *found_pool) {
 
 /* *************************************** */
 
-bool HostPools::findIpNode(IpAddress *ip, u_int16_t vlan_id, patricia_node_t **found_node) {
+bool HostPools::findIpPool(IpAddress *ip, u_int16_t vlan_id, u_int16_t *found_pool, patricia_node_t **found_node) {
   AddressTree *cur_tree; /* must use this as tree can be swapped */
 #ifdef HOST_POOLS_DEBUG
   char buf[128];
@@ -644,6 +644,7 @@ bool HostPools::findIpNode(IpAddress *ip, u_int16_t vlan_id, patricia_node_t **f
 				   "Found pool for %s [pool id: %i]",
 				   ip->print(buf, sizeof(buf)), (*found_node)->user_data);
 #endif
+      *found_pool = (*found_node)->user_data;
       return true;
   }
 
@@ -655,13 +656,15 @@ bool HostPools::findIpNode(IpAddress *ip, u_int16_t vlan_id, patricia_node_t **f
 
 u_int16_t HostPools::getPool(Host *h) {
   u_int16_t pool_id;
+  patricia_node_t *node;
   bool found = false;
 
   if(h) {
     if(h->getMac())
       found = findMacPool(h->getMac(), &pool_id);
-    if (!found && h->get_ip())
-      found = findIpPool(h->get_ip(), h->get_vlan_id(), &pool_id);
+    if (!found && h->get_ip()) {
+      found = findIpPool(h->get_ip(), h->get_vlan_id(), &pool_id, &node);
+    }
   }
 
   if (! found)

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -615,10 +615,9 @@ bool HostPools::findMacPool(Mac *mac, u_int16_t *found_pool) {
       ntop->getTrace()->traceEvent(TRACE_NORMAL,
 				   "Found pool for %s [pool id: %i]",
 				   k, ret);
-
+#endif
       *found_pool = (u_int16_t)ret;
       return true;
-#endif
     }
   }
 

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -596,20 +596,17 @@ void HostPools::reloadPools() {
 
 /* *************************************** */
 
-u_int16_t HostPools::getPool(Host *h) {
-  Mac *mac;
-  IpAddress *ip;
-  patricia_node_t *node;
+bool HostPools::findMacPool(Mac *mac, u_int16_t *found_pool) {
   AddressTree *cur_tree; /* must use this as tree can be swapped */
 #ifdef HOST_POOLS_DEBUG
   char buf[128];
   char *k;
 #endif
 
-  if(!h || !tree || !(cur_tree = tree[h->get_vlan_id()]))
-    return NO_HOST_POOL_ID;
+  if(!tree || !(cur_tree = tree[mac->get_vlan_id()]))
+    return false;
 
-  if((mac = h->getMac()) && !mac->isSpecialMac()) {
+  if (!mac->isSpecialMac()) {
     int16_t ret = mac->findAddress(cur_tree);
 
     if(ret != -1) {
@@ -618,23 +615,56 @@ u_int16_t HostPools::getPool(Host *h) {
       ntop->getTrace()->traceEvent(TRACE_NORMAL,
 				   "Found pool for %s [pool id: %i]",
 				   k, ret);
-#endif
 
-      return((u_int16_t)ret);
+      *found_pool = (u_int16_t)ret;
+      return true;
+#endif
     }
   }
 
-  if((ip = h->get_ip())) {
-    node = (patricia_node_t*)ip->findAddress(cur_tree);
-    if(node) {
+  return false;
+}
+
+/* *************************************** */
+
+bool HostPools::findIpNode(IpAddress *ip, u_int16_t vlan_id, patricia_node_t **found_node) {
+  AddressTree *cur_tree; /* must use this as tree can be swapped */
+#ifdef HOST_POOLS_DEBUG
+  char buf[128];
+  char *k;
+#endif
+
+  if(!tree || !(cur_tree = tree[vlan_id]))
+    return false;
+
+  *found_node = (patricia_node_t*)ip->findAddress(cur_tree);
+  if(*found_node) {
 #ifdef HOST_POOLS_DEBUG
       ntop->getTrace()->traceEvent(TRACE_NORMAL,
 				   "Found pool for %s [pool id: %i]",
-				   h->get_ip()->print(buf, sizeof(buf)), node->user_data);
+				   ip->print(buf, sizeof(buf)), (*found_node)->user_data);
 #endif
-      return node->user_data;
-    }
+      return true;
   }
 
-  return NO_HOST_POOL_ID;
+  return false;
+}
+
+
+/* *************************************** */
+
+u_int16_t HostPools::getPool(Host *h) {
+  u_int16_t pool_id;
+  bool found = false;
+
+  if(h) {
+    if(h->getMac())
+      found = findMacPool(h->getMac(), &pool_id);
+    if (!found && h->get_ip())
+      found = findIpPool(h->get_ip(), h->get_vlan_id(), &pool_id);
+  }
+
+  if (! found)
+    return NO_HOST_POOL_ID;
+  return pool_id;
 }

--- a/src/Lua.cpp
+++ b/src/Lua.cpp
@@ -3624,9 +3624,7 @@ static int ntop_find_member_pool(lua_State *vm) {
       IpAddress ip;
       ip.set(address);
 
-      pool_found = ntop_interface->getHostPools()->findIpNode(&ip, vlan_id, &target_node);
-      if(pool_found)
-        pool_id = target_node->user_data;
+      pool_found = ntop_interface->getHostPools()->findIpPool(&ip, vlan_id, &pool_id, &target_node);
     }
 
     if (pool_found) {

--- a/src/Lua.cpp
+++ b/src/Lua.cpp
@@ -1221,6 +1221,33 @@ static int ntop_inet_ntoa(lua_State* vm) {
 
 /* ****************************************** */
 
+/**
+ * @brief Mask an IPv4/v6 address with a bitmask and return the network prefix.
+ *
+ * @param vm The lua state.
+ * @return CONST_LUA_OK.
+ */
+static int ntop_network_prefix(lua_State* vm) {
+  char *address;
+  char buf[64];
+  u_int8_t mask;
+  IpAddress ip;
+
+  ntop->getTrace()->traceEvent(TRACE_DEBUG, "%s() called", __FUNCTION__);
+
+  if(ntop_lua_check(vm, __FUNCTION__, 1, LUA_TSTRING)) return(CONST_LUA_PARAM_ERROR);
+  if((address = (char*)lua_tostring(vm, 1)) == NULL)  return(CONST_LUA_PARAM_ERROR);
+
+  if(ntop_lua_check(vm, __FUNCTION__, 2, LUA_TNUMBER)) return(CONST_LUA_PARAM_ERROR);
+  mask = (int)lua_tonumber(vm, 2);
+
+  ip.set(address);
+  lua_pushstring(vm, ip.print(buf, sizeof(buf), mask));
+  return(CONST_LUA_OK);
+}
+
+/* ****************************************** */
+
 static int ntop_zmq_connect(lua_State* vm) {
   char *endpoint, *topic;
   void *context, *subscriber;
@@ -3566,6 +3593,64 @@ static int ntop_remove_volatile_member_from_pool(lua_State *vm) {
 #endif
 /* ****************************************** */
 
+static int ntop_find_member_pool(lua_State *vm) {
+  char *address;
+  u_int16_t vlan_id;
+  bool is_mac;
+  patricia_node_t *target_node = NULL;
+  u_int16_t pool_id;
+  bool pool_found;
+  char buf[64];
+
+  NetworkInterface *ntop_interface = getCurrentInterface(vm);
+
+  if(ntop_lua_check(vm, __FUNCTION__, 1, LUA_TSTRING)) return(CONST_LUA_PARAM_ERROR);
+  if((address = (char*)lua_tostring(vm, 1)) == NULL)  return(CONST_LUA_PARAM_ERROR);
+
+  if(ntop_lua_check(vm, __FUNCTION__, 2, LUA_TNUMBER)) return(CONST_LUA_PARAM_ERROR);
+  vlan_id = (u_int16_t)lua_tonumber(vm, 2);
+
+  if(ntop_lua_check(vm, __FUNCTION__, 3, LUA_TBOOLEAN)) return(CONST_LUA_PARAM_ERROR);
+  is_mac = lua_toboolean(vm, 3);
+
+  if (ntop_interface && ntop_interface->getHostPools()) {
+    if (is_mac) {
+      u_int8_t mac_bytes[6];
+      Utils::parseMac(mac_bytes, address);
+      Mac mac(ntop_interface, mac_bytes, vlan_id);
+
+      pool_found = ntop_interface->getHostPools()->findMacPool(&mac, &pool_id);
+    } else {
+      IpAddress ip;
+      ip.set(address);
+
+      pool_found = ntop_interface->getHostPools()->findIpNode(&ip, vlan_id, &target_node);
+      if(pool_found)
+        pool_id = target_node->user_data;
+    }
+
+    if (pool_found) {
+      lua_newtable(vm);
+      lua_push_int_table_entry(vm, "pool_id", pool_id);
+
+      if (target_node != NULL) {
+        lua_push_str_table_entry(vm, "matched_prefix", (char *)inet_ntop(target_node->prefix->family,
+                (target_node->prefix->family == AF_INET6) ?
+                  (void*)(&target_node->prefix->add.sin6) :
+                  (void*)(&target_node->prefix->add.sin),
+                buf, sizeof(buf)));
+        lua_push_int_table_entry(vm, "matched_bitmask", target_node->bit);
+      }
+    } else
+      lua_pushnil(vm);
+
+    return(CONST_LUA_OK);
+  } else
+    return(CONST_LUA_ERROR);
+}
+
+/* *******************************************/
+
 static int ntop_reload_l7_rules(lua_State *vm) {
   NetworkInterface *ntop_interface = getCurrentInterface(vm);
 
@@ -5660,6 +5745,7 @@ static const luaL_Reg ntop_interface_reg[] = {
   { "getHostPoolsVolatileMembers",    ntop_get_host_pool_volatile_members   },
   { "purgeExpiredPoolsMembers",       ntop_purge_expired_host_pools_members },
   { "removeVolatileMemberFromPool",   ntop_remove_volatile_member_from_pool },
+  { "findMemberPool",                 ntop_find_member_pool },
   
   /* SNMP */
   { "getSNMPStats",                   ntop_interface_get_snmp_stats },
@@ -5782,6 +5868,7 @@ static const luaL_Reg ntop_reg[] = {
 
   /* IP */
   { "inet_ntoa",      ntop_inet_ntoa },
+  { "networkPrefix",  ntop_network_prefix },
 
   /* RRD */
   { "rrd_create",     ntop_rrd_create },


### PR DESCRIPTION
Enforces MAC/Host/Network consistency across Host Pools. Fixes #1130.

- Networks are now normalized with their network prefix before being dumped to Redis
- No network duplication is now possible inside the same pool or between different pools

Note: currently, checks are currently implemented Lua side. No javascript / ajax errors are shown when an addPoolMember operation fails.