### PR TITLE
Fix: bubble charts are not displayed

### DIFF
--- a/scripts/lua/hosts_comparison_bubble.lua
+++ b/scripts/lua/hosts_comparison_bubble.lua
@@ -79,7 +79,7 @@ else
     end
 
     -- 1.    Find all flows between compared hosts
-    flows_stats = interface.getFlowsInfo()
+    flows_stats = interface.getFlowsInfo(nil,{detailsLevel="higher"})
     flows_stats = flows_stats["flows"]
 
     ndpi = {}


### PR DESCRIPTION
Bubble charts for application and L4 protocol between hosts are not displayed. It is solved to pass the detailsLevel="higher" option for getFlowsInfo.