### PR TITLE
FreeBSD fetch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,14 @@ GPP=@CXX@
 INSTALL_DIR=$(DESTDIR)$(prefix)
 MAN_DIR=$(DESTDIR)@MAN_DIR@
 
+# FreeBSD does not include wget by default, but the base system
+# includes fetch, which provides similar functionality.
+ifeq ($(OS), $(filter $(OS), FreeBSD))
+	GET_UTIL = fetch
+else
+	GET_UTIL = wget -nc
+endif
+
 ######
 HAS_NDPI=$(shell pkg-config --exists libndpi; echo $$?)
 ifeq ($(HAS_NDPI), 0)
@@ -180,10 +188,10 @@ geoip:
 	  cp ~/dat_files/* httpdocs/geoip; gunzip -f httpdocs/geoip/*.dat.gz ; \
 	else \
 	  cd httpdocs/geoip; \
-	  wget -nc http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
-	  wget -nc http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz; \
-	  wget -nc http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz; \
-	  wget -nc http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz; \
+	  $(GET_UTIL) http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz; \
+	  $(GET_UTIL) http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz; \
+	  $(GET_UTIL) http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz; \
+	  $(GET_UTIL) http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz; \
 	  gunzip -f *.dat.gz ; \
 	fi
 

--- a/doc/README.FreeBSD
+++ b/doc/README.FreeBSD
@@ -1,6 +1,6 @@
 Note that you need to edit third-party/LuaJIT-X.Y.Z/src/Makefile and change "CC= gcc" into "CC= cc" prior to start the compilation.
 
-pkg install git wget autoconf autoconf-wrapper automake automake-wrapper fontconfig libtool sqlite3 mysql56-client libxml2 glib gmake bash rrdtool redis pkgconf flex bison sudo GeoIP geoip
+pkg install git autoconf autoconf-wrapper automake automake-wrapper fontconfig libtool sqlite3 mysql56-client libxml2 glib gmake bash rrdtool redis pkgconf flex bison sudo GeoIP geoip
 
 echo 'redis_enable="YES"' >> /etc/rc.conf
 service redis start


### PR DESCRIPTION
While most linux distributions come with wget preinstalled, FreeBSD does not include it by default. OTOH FreeBSD base system includes a "fetch" command which provides similar functionality.

I modified the Makefile.in to use fetch in place of wget on FreeBSD OS.