### PR TITLE
RPM improvements

### DIFF
--- a/packages/etc/systemd/system/ntopng-pcap.service
+++ b/packages/etc/systemd/system/ntopng-pcap.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Start/stop ntopng program without pfring support
+After=network-online.target syslog.target redis.service
+Requires=redis.service
+
+[Service]
+Type=forking
+RemainAfterExit=yes
+ExecStart=/etc/init.d/ntopng start
+ExecStop=/etc/init.d/ntopng stop
+Restart=on-abnormal
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/etc/systemd/system/ntopng.service
+++ b/packages/etc/systemd/system/ntopng.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start/stop ntopng program
-After=network.target syslog.target redis.service pf_ring.service cluster.service
+After=network-online.target syslog.target redis.service pf_ring.service cluster.service
 Requires=pf_ring.service cluster.service
 
 [Service]

--- a/packages/ntopng-data.spec.in
+++ b/packages/ntopng-data.spec.in
@@ -1,35 +1,22 @@
 Summary: GeoIP databases for ntopng
 Name: ntopng-data
 Version: @NTOPNG_VERSION@
-Release: @REVISION@
+Release: @REVISION@%{?dist}
 License: GPL
-Group: Networking/Utilities
 URL: http://www.ntop.org/
 Source: ntopng-data-%{version}.tgz
-Packager: Luca Deri <deri@ntop.org>
 BuildArch: noarch
-# Temporary location where the RPM will be built
-BuildRoot:  %{_tmppath}/%{name}-%{version}-root
-#Requires: ntopng
 
 %description
 GeoIP databases for ntopng
 
-%prep
-
 %build
 
-mkdir -p $RPM_BUILD_ROOT/usr/share/ntopng/httpdocs/geoip
-cp $HOME/ntopng/httpdocs/geoip/*.dat* $RPM_BUILD_ROOT/usr/share/ntopng/httpdocs/geoip
-find $RPM_BUILD_ROOT/usr/share/ntopng/httpdocs/geoip -name "*.gz" |xargs gunzip -f
-find $RPM_BUILD_ROOT -name ".svn" | xargs /bin/rm -rf
-find $RPM_BUILD_ROOT -name "*~"   | xargs /bin/rm -f
-#
-DST=$RPM_BUILD_ROOT/usr/ntopng
-SRC=$RPM_BUILD_DIR/%{name}-%{version}
-# Clean out our build directory
-%clean
-rm -fr $RPM_BUILD_ROOT
+mkdir -p %{buildroot}/usr/share/ntopng/httpdocs/geoip
+cp $HOME/ntopng/httpdocs/geoip/*.dat* %{buildroot}/usr/share/ntopng/httpdocs/geoip
+find %{buildroot}/usr/share/ntopng/httpdocs/geoip -name "*.gz" |xargs gunzip -f
+find %{buildroot} -name ".svn" | xargs /bin/rm -rf
+find %{buildroot} -name "*~"   | xargs /bin/rm -f
 
 %files
 /usr/share/ntopng/httpdocs/geoip/GeoIPASNum.dat

--- a/packages/ntopng.spec.in
+++ b/packages/ntopng.spec.in
@@ -3,15 +3,11 @@ Name: ntopng
 Version: @NTOPNG_VERSION@
 Release: @REVISION@
 License: GPL
-Group: Networking/Utilities
 URL: http://www.ntop.org/
 Source: ntopng-%{version}.tgz
-Packager: Luca Deri <deri@ntop.org>
-# Temporary location where the RPM will be built
-BuildRoot:  %{_tmppath}/%{name}-%{version}-root
 Requires: pfring = @PFRING_VERSION@-@PFRING_GIT_RELEASE@, redis >= 2.4.0, GeoIP >= 1.4.8, rrdtool >= 1.3.8, numactl, libcurl, ntopng-data, logrotate, zeromq >= 4.0.0, openldap, openssl, hiredis, mysql, libnetfilter_queue, ethtool, bridge-utils
 # Disable shared libs dependency check (needed by FPGA libs)
-AutoReqProv: no
+AutoReq: no
 
 %description
 Web-based traffic monitoring
@@ -31,46 +27,42 @@ if ! test -f "$HOME/ntopng/pro/utils/snzip"; then echo "snzip missing"; exit; fi
 # may need to manually install files with the install command.
 %install
 PATH=/usr/bin:/bin:/usr/sbin:/sbin
-if [ -d $RPM_BUILD_ROOT ]; then
-	\rm -rf $RPM_BUILD_ROOT
+if [ -d %{buildroot} ]; then
+	\rm -rf %{buildroot}
 fi
 
-mkdir -p $RPM_BUILD_ROOT/usr/bin $RPM_BUILD_ROOT/usr/share/ntopng $RPM_BUILD_ROOT/usr/share/man/man8 
-mkdir -p $RPM_BUILD_ROOT/etc/init.d $RPM_BUILD_ROOT/etc/logrotate.d
-cp $HOME/ntopng/ntopng $RPM_BUILD_ROOT/usr/bin
-cp $HOME/ntopng/ntopng.8 $RPM_BUILD_ROOT/usr/share/man/man8/ 
-cp -Lr $HOME/ntopng/httpdocs $HOME/ntopng/scripts $RPM_BUILD_ROOT/usr/share/ntopng  # L to dereference symlinks
+mkdir -p %{buildroot}/usr/bin %{buildroot}/usr/share/ntopng %{buildroot}/usr/share/man/man8 
+mkdir -p %{buildroot}/etc/init.d %{buildroot}/etc/logrotate.d
+cp $HOME/ntopng/ntopng %{buildroot}/usr/bin
+cp $HOME/ntopng/ntopng.8 %{buildroot}/usr/share/man/man8/ 
+cp -Lr $HOME/ntopng/httpdocs $HOME/ntopng/scripts %{buildroot}/usr/share/ntopng  # L to dereference symlinks
 # Make sure dat files are not packaged by ntopng as they belong to ntopng-data
-rm -f $RPM_BUILD_ROOT/usr/share/ntopng/httpdocs/geoip/*dat
-mv $RPM_BUILD_ROOT/usr/share/ntopng/httpdocs/ssl/ntopng-cert.pem.dummy $RPM_BUILD_ROOT/usr/share/ntopng/httpdocs/ssl/ntopng-cert.pem
+rm -f %{buildroot}/usr/share/ntopng/httpdocs/geoip/*dat
+mv %{buildroot}/usr/share/ntopng/httpdocs/ssl/ntopng-cert.pem.dummy %{buildroot}/usr/share/ntopng/httpdocs/ssl/ntopng-cert.pem
 if test -d "$HOME/ntopng/pro"; then
    cd $HOME/ntopng/pro; make; cd -
-   mkdir $RPM_BUILD_ROOT/usr/share/ntopng/pro
-   cp -r $HOME/ntopng/pro/httpdocs $RPM_BUILD_ROOT/usr/share/ntopng/pro
-   cp -r $HOME/ntopng/pro/scripts $RPM_BUILD_ROOT/usr/share/ntopng/pro
-   cd $RPM_BUILD_ROOT/usr/share/ntopng/scripts/lua; ln -s ../../pro/scripts/lua pro
-   find $RPM_BUILD_ROOT/usr/share/ntopng/pro -name "*.lua" -type f -exec $HOME/ntopng/pro/utils/snzip -c -i {} -o {}r \;
-   find $RPM_BUILD_ROOT/usr/share/ntopng/pro -name "*.lua" -type f -exec /bin/rm  {} ';'
-   find $RPM_BUILD_ROOT/usr/share/ntopng/pro -name "*.luar" | xargs rename .luar .lua
+   mkdir %{buildroot}/usr/share/ntopng/pro
+   cp -r $HOME/ntopng/pro/httpdocs %{buildroot}/usr/share/ntopng/pro
+   cp -r $HOME/ntopng/pro/scripts %{buildroot}/usr/share/ntopng/pro
+   cd %{buildroot}/usr/share/ntopng/scripts/lua; ln -s ../../pro/scripts/lua pro
+   find %{buildroot}/usr/share/ntopng/pro -name "*.lua" -type f -exec $HOME/ntopng/pro/utils/snzip -c -i {} -o {}r \;
+   find %{buildroot}/usr/share/ntopng/pro -name "*.lua" -type f -exec /bin/rm  {} ';'
+   find %{buildroot}/usr/share/ntopng/pro -name "*.luar" | xargs rename .luar .lua
 fi
 
-#cp $HOME/ntopng/packages/etc/init/ntopng.conf $RPM_BUILD_ROOT/etc/init
+#cp $HOME/ntopng/packages/etc/init/ntopng.conf %{buildroot}/etc/init
 if test -d "/etc/systemd"; then
-   mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/
-   cp $HOME/ntopng/packages/etc/systemd/system/ntopng.service    $RPM_BUILD_ROOT/etc/systemd/system/
+   mkdir -p %{buildroot}/etc/systemd/system/
+   cp $HOME/ntopng/packages/etc/systemd/system/ntopng.service    %{buildroot}/etc/systemd/system/
 fi
-cp $HOME/ntopng/packages/etc/init.d/ntopng    $RPM_BUILD_ROOT/etc/init.d
-cp $HOME/ntopng/packages/etc/logrotate.d/ntopng    $RPM_BUILD_ROOT/etc/logrotate.d/
-find $RPM_BUILD_ROOT -name ".git" | xargs /bin/rm -rf
-find $RPM_BUILD_ROOT -name ".svn" | xargs /bin/rm -rf
-find $RPM_BUILD_ROOT -name "*~"   | xargs /bin/rm -f
+cp $HOME/ntopng/packages/etc/init.d/ntopng    %{buildroot}/etc/init.d
+cp $HOME/ntopng/packages/etc/logrotate.d/ntopng    %{buildroot}/etc/logrotate.d/
+find %{buildroot} -name ".git" | xargs /bin/rm -rf
+find %{buildroot} -name ".svn" | xargs /bin/rm -rf
+find %{buildroot} -name "*~"   | xargs /bin/rm -f
 #
-DST=$RPM_BUILD_ROOT/usr/ntopng
-SRC=$RPM_BUILD_DIR/%{name}-%{version}
-#mkdir -p $DST/conf
-# Clean out our build directory
-%clean
-rm -fr $RPM_BUILD_ROOT
+#DST=%{buildroot}/usr/ntopng
+#SRC=$RPM_BUILD_DIR/%{name}-%{version}
 
 %files
 /usr/bin/ntopng

--- a/packages/ntopng.spec.in
+++ b/packages/ntopng.spec.in
@@ -1,7 +1,7 @@
 Summary: Web-based network traffic monitoring
 Name: ntopng
 Version: @NTOPNG_VERSION@
-Release: @REVISION@
+Release: @REVISION@%{?dist}
 License: GPL
 URL: http://www.ntop.org/
 Source: ntopng-%{version}.tgz

--- a/packages/ntopng.spec.in
+++ b/packages/ntopng.spec.in
@@ -109,8 +109,6 @@ esac
 %endif
 
 %post
-echo 'Setting up redis auto startup'
-/sbin/chkconfig redis on
 if test -d /usr/local/share/ntopng ; then  
     echo 'Moving ntopng to ntopng.disabled'
     mv /usr/local/share/ntopng /usr/local/share/ntopng.disabled; 
@@ -118,6 +116,8 @@ fi
 %if 0%{?centos_ver} == 7
 %systemd_post ntopng.service
 %else
+echo 'Setting up redis auto startup'
+/sbin/chkconfig redis on
 /sbin/chkconfig --add ntopng
 case "$1" in
   1)

--- a/packages/ntopng.spec.in
+++ b/packages/ntopng.spec.in
@@ -8,6 +8,10 @@ Source: ntopng-%{version}.tgz
 Requires: pfring = @PFRING_VERSION@-@PFRING_GIT_RELEASE@, redis >= 2.4.0, GeoIP >= 1.4.8, rrdtool >= 1.3.8, numactl, libcurl, ntopng-data, logrotate, zeromq >= 4.0.0, openldap, openssl, hiredis, mysql, libnetfilter_queue, ethtool, bridge-utils
 # Disable shared libs dependency check (needed by FPGA libs)
 AutoReq: no
+%if 0%{?centos_ver} == 7
+%{?systemd_requires}
+BuildRequires: systemd
+%endif
 
 %description
 Web-based traffic monitoring
@@ -50,34 +54,32 @@ if test -d "$HOME/ntopng/pro"; then
    find %{buildroot}/usr/share/ntopng/pro -name "*.luar" | xargs rename .luar .lua
 fi
 
-#cp $HOME/ntopng/packages/etc/init/ntopng.conf %{buildroot}/etc/init
 if test -d "/etc/systemd"; then
-   mkdir -p %{buildroot}/etc/systemd/system/
-   cp $HOME/ntopng/packages/etc/systemd/system/ntopng.service    %{buildroot}/etc/systemd/system/
+   mkdir -p %{buildroot}/%{_unitdir}
+   cp $HOME/ntopng/packages/etc/systemd/system/ntopng.service  %{buildroot}/%{_unitdir}
 fi
 cp $HOME/ntopng/packages/etc/init.d/ntopng    %{buildroot}/etc/init.d
 cp $HOME/ntopng/packages/etc/logrotate.d/ntopng    %{buildroot}/etc/logrotate.d/
 find %{buildroot} -name ".git" | xargs /bin/rm -rf
 find %{buildroot} -name ".svn" | xargs /bin/rm -rf
 find %{buildroot} -name "*~"   | xargs /bin/rm -f
-#
-#DST=%{buildroot}/usr/ntopng
-#SRC=$RPM_BUILD_DIR/%{name}-%{version}
+
+# Creating link under /usr/local/bin
+mkdir -p %{buildroot}/usr/local/bin/
+ln -sf /usr/bin/ntopng %{buildroot}/usr/local/bin/ntopng
 
 %files
 /usr/bin/ntopng
 /usr/share/man/man8/ntopng.8.gz
-#/etc/init/ntopng.conf
 %if 0%{?centos_ver} == 7
-/etc/systemd/system/ntopng.service
+%{_unitdir}/ntopng.service
 %endif
 /etc/init.d/ntopng
 /etc/logrotate.d/ntopng
 /usr/share/ntopng
+/usr/local/bin/ntopng
 # Don't overwrite ntopng-cert.pem is the file is already present
 %config(noreplace) /usr/share/ntopng/httpdocs/ssl/ntopng-cert.pem
-#/etc/ntopng/ntopng.conf.sample
-#/etc/ntopng/ntopng.start
 
 # Set the default attributes of all of the files specified to have an
 # owner and group of root and to inherit the permissions of the file
@@ -94,6 +96,7 @@ find %{buildroot} -name "*~"   | xargs /bin/rm -f
 # un-install:                          preun       -> (delete)     -> postun
 
 %pre
+%if 0%{?centos_ver} != 7
 case "$1" in
   1)
     # install
@@ -103,19 +106,19 @@ case "$1" in
     /etc/init.d/ntopng stop
   ;;
 esac
+%endif
 
 %post
 echo 'Setting up redis auto startup'
 /sbin/chkconfig redis on
-echo 'Creating link under /usr/local/bin'
-if test ! -e /usr/local/bin/ntopng ; then ln -s /usr/bin/ntopng /usr/local/bin/ntopng ; fi
-if test -d /usr/local/share/ntopng ; then  mv /usr/local/share/ntopng /usr/local/share/ntopng.disabled; fi
+if test -d /usr/local/share/ntopng ; then  
+    echo 'Moving ntopng to ntopng.disabled'
+    mv /usr/local/share/ntopng /usr/local/share/ntopng.disabled; 
+fi
 %if 0%{?centos_ver} == 7
-/bin/systemctl daemon-reload
-/bin/systemctl enable ntopng.service
+%systemd_post ntopng.service
 %else
 /sbin/chkconfig --add ntopng
-%endif
 case "$1" in
   1)
     # install
@@ -126,22 +129,25 @@ case "$1" in
     /etc/init.d/ntopng start
   ;;
 esac
+%endif
 
 %preun
-case "$1" in
-  0)
-    # un-install
-    /etc/init.d/ntopng stop
-  ;;
-  1)
-    # upgrade
-  ;;
-esac
 %if 0%{?centos_ver} == 7
-  /bin/systemctl disable ntopng.service
+  %systemd_preun ntopng.service
 %else
+
+  case "$1" in
+    0)
+      # un-install
+      /etc/init.d/ntopng stop
+    ;;
+    1)
+      # upgrade
+    ;;
+  esac
+
   /sbin/chkconfig --del ntopng
 %endif
-if [ $1 == 0 ] ; then
-    rm -f /usr/local/bin/ntopng > /dev/null 2>&1
-fi
+
+%postun
+%systemd_postun_with_restart ntopng.service

--- a/packages/ntopng.spec.in
+++ b/packages/ntopng.spec.in
@@ -13,8 +13,33 @@ AutoReq: no
 BuildRequires: systemd
 %endif
 
+%package pcap
+Requires: redis >= 2.4.0, GeoIP >= 1.4.8, rrdtool >= 1.3.8, numactl, libcurl, ntopng-data, logrotate, zeromq >= 4.0.0, openldap, openssl, hiredis, mysql, libnetfilter_queue, ethtool, bridge-utils
+Summary: ntopng without pfring
+AutoReq: no
+%description pcap
+ntopng without pfring
+%files pcap
+%defattr(-, root, root)
+/usr/bin/ntopng
+/usr/share/man/man8/ntopng.8.gz
+%if 0%{?centos_ver} == 7
+%{_unitdir}/ntopng.service
+%{_unitdir}/ntopng.service.d/ntopng-pcap.service
+%endif
+/etc/init.d/ntopng
+/etc/logrotate.d/ntopng
+/usr/share/ntopng
+/usr/local/bin/ntopng
+%config(noreplace) /usr/share/ntopng/httpdocs/ssl/ntopng-cert.pem
+
+%changelog pcap
+* Tue Aug 29 2017 Giacomo Sanchietti - @NTOPNG_VERSION@-@REVISION@
+- First release
+
+
 %description
-Web-based traffic monitoring
+Web-based traffic monitoring (without pfring support)
 
 %setup -q
 
@@ -57,6 +82,8 @@ fi
 if test -d "/etc/systemd"; then
    mkdir -p %{buildroot}/%{_unitdir}
    cp $HOME/ntopng/packages/etc/systemd/system/ntopng.service  %{buildroot}/%{_unitdir}
+   mkdir %{buildroot}/%{_unitdir}/ntopng.service.d
+   cp $HOME/ntopng/packages/etc/systemd/system/ntopng-pcap.service %{buildroot}/%{_unitdir}/ntopng.service.d
 fi
 cp $HOME/ntopng/packages/etc/init.d/ntopng    %{buildroot}/etc/init.d
 cp $HOME/ntopng/packages/etc/logrotate.d/ntopng    %{buildroot}/etc/logrotate.d/


### PR DESCRIPTION
- Cleanup obsolete tags and scriplets
- Use systemd macros for CentOS 7
- Move systemd unit files to `/usr/lib/systemd/system/n` directory
- Create new ntopng-pcap package without pfring (and dkms) dependencies

`%changelog` sections of both RPMs should be updated before stable release.
