### PR TITLE
Rename LIBS variable to avoid polluting the environment of submakes l…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -106,7 +106,7 @@ endif
 
 ######
 TARGET = ntopng
-LIBS = $(NDPI_LIB) $(LIBPCAP) $(LUAJIT_LIB) $(LIBRRDTOOL_LIB) $(LIBNBPF_LIB) $(ZEROMQ_LIB) $(JSON_LIB) $(SODIUM_LIB) @HIREDIS_LIB@ @SQLITE_LIB@ @MYSQL_LIB@ @SSL_LIB@ @LINK_OPTS@ @GEOIP_LIB@ @LDFLAGS@ @PRO_LIBS@ -lm -lpthread
+NLIBS = $(NDPI_LIB) $(LIBPCAP) $(LUAJIT_LIB) $(LIBRRDTOOL_LIB) $(LIBNBPF_LIB) $(ZEROMQ_LIB) $(JSON_LIB) $(SODIUM_LIB) @HIREDIS_LIB@ @SQLITE_LIB@ @MYSQL_LIB@ @SSL_LIB@ @LINK_OPTS@ @GEOIP_LIB@ @LDFLAGS@ @PRO_LIBS@ -lm -lpthread
 CPPFLAGS = -g @CFLAGS@ @HIREDIS_INC@ $(MONGOOSE_INC) $(JSON_INC) $(SODIUM_INC) $(NDPI_INC) $(LUAJIT_INC) $(LIBRRDTOOL_INC) $(ZEROMQ_INC) @MYSQL_INC@ @CPPFLAGS@ -I$(HTTPCLIENT_INC) @SSL_INC@ @PRO_INCS@ -DDATA_DIR='"$(datadir)"' -I${PWD}/third-party/libgeohash -I${PWD}/third-party/patricia # -D_GLIBCXX_DEBUG
 ######
 # ntopng-1.0_1234.x86_64.rpm
@@ -120,7 +120,7 @@ RPM_DATA_PKG = $(TARGET)-data-$(NTOPNG_VERSION)-@REVISION@.noarch.rpm
 ######
 
 ifeq ($(OS),Darwin)
-LIBS += -lstdc++.6
+NLIBS += -lstdc++.6
 endif
 
 LIB_TARGETS =
@@ -161,7 +161,7 @@ HEADERS = $(wildcard include/*.h) @PRO_HEADERS@
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS) $(LIBRRDTOOL) Makefile
-	$(GPP) $(OBJECTS) -Wall $(LIBS) -o $@
+	$(GPP) $(OBJECTS) -Wall $(NLIBS) -o $@
 
 $(LUAJIT_LIB):
 	cd $(LUAJIT_HOME); @GMAKE@


### PR DESCRIPTION
…aunched to compile third party libraries.

While porting the latest version to FreeBSD I had to use the luajit library in the third_parties directory.

It failed to build because hte LIBS variable is polluted by the top level Makefile with the luajit library itself, failing to build the minilua compiler.

This patch fixes it by renaming the LIBS variable in the top level Makefile.