### PR TITLE
Modify files to allow compiling using llvm/clang 6.0.0 as recently im…

### DIFF
--- a/src/DivertInterface.cpp
+++ b/src/DivertInterface.cpp
@@ -101,7 +101,7 @@ DivertInterface::DivertInterface(const char *name) : NetworkInterface(name) {
   sin.sin_family = AF_INET, sin.sin_port = htons(port);
   sin_len = sizeof(struct sockaddr_in);
 
-  if(bind(sock, (struct sockaddr *) &sin, sin_len) == -1) {
+  if(::bind(sock, (struct sockaddr *) &sin, sin_len) == -1) {
     ntop->getTrace()->traceEvent(TRACE_ERROR, "Unable to bind divert socket to port %d", port);
     throw 1;
   }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -2380,7 +2380,7 @@ int Utils::bindSockToDevice(int sock, int family, const char* devicename) {
 
   if(pAdapterFound != NULL) {
     int addrsize = (family == AF_INET6) ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
-    bindresult = bind(sock, pAdapterFound->ifa_addr, addrsize);
+    bindresult = ::bind(sock, pAdapterFound->ifa_addr, addrsize);
   }
 
   freeifaddrs(pList);

--- a/third-party/mongoose/mongoose.c
+++ b/third-party/mongoose/mongoose.c
@@ -730,7 +730,7 @@ struct mg_request_info *mg_get_request_info(struct mg_connection *conn) {
   return &conn->request_info;
 }
 
-static void mg_strlcpy(register char *dst, register const char *src, size_t n) {
+static void mg_strlcpy(char *dst, const char *src, size_t n) {
   for (; *src != '\0' && n > 1; n--) {
     *dst++ = *src++;
   }
@@ -2139,7 +2139,7 @@ static void MD5Init(MD5_CTX *ctx) {
 }
 
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16]) {
-  register uint32_t a, b, c, d;
+  uint32_t a, b, c, d;
 
   a = buf[0];
   b = buf[1];
@@ -4511,7 +4511,7 @@ static int set_ports_option(struct mg_context *ctx) {
 					   (void *)
 #endif
 					   &on, sizeof(on))) != 0 ||
-	       (rc_bind = bind(so.sock,
+	       (rc_bind = ::bind(so.sock,
 			       &sa->sa,
 			       (sa->sa.sa_family == AF_INET) ? sizeof(sa->sin) : sizeof(sa->sin6))
 		) != 0 ||

--- a/third-party/snmp/net.c
+++ b/third-party/snmp/net.c
@@ -64,7 +64,7 @@ int open_udp_socket(int port)
   si_me.sin_family = AF_INET;
   si_me.sin_port = htons(port);
   si_me.sin_addr.s_addr = htonl(INADDR_ANY);
-  if (bind(s, (struct sockaddr *) &si_me, sizeof(si_me)) != 0)
+  if (::bind(s, (struct sockaddr *) &si_me, sizeof(si_me)) != 0)
     return(-1); //diep("bind");
     
   return s;


### PR DESCRIPTION
…ported in FreeBSD 12-CURRENT.

These are brutal modifications I made to make ntopng compile on recent FreeBSD head, after the import of clang 6.0.0.
I made two modifications around.

1) Removed "register" qualifiers. clang has them as deprecated and errors out on them by default now. It states they are incompatible with c++17 standard. I don't think this is a problem. Modern compilers are able to optimise without needing such suggestions.

2) Modified plain calls to bind(2) to explicitly reference bind in the root namespace. If unqualified clang now tries to use the overloaded bind function in the std namespace, which is unrelated.

I can agree that 2 is somewhat brutal and maybe some preprocessor macro trick could be better. I'm open to suggestions on how to make my patch better.

All these changes should also be merged back to the 3.2-stable branch if accepted.