### PR TITLE
Fixes systemd comment regex

### DIFF
--- a/packages/etc/systemd/system/ntopng.service.in
+++ b/packages/etc/systemd/system/ntopng.service.in
@@ -5,7 +5,7 @@ Wants=@SERVICE_REQUIRES@
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c '/bin/sed "/^\s*-e$\\|^\s*-G.*\\|--daemon.*\\|^\s*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
+ExecStartPre=/bin/sh -c '/bin/sed "/^[ \t]*-e$\\|^[ \t]*-G.*\\|--daemon.*\\|^[ \t]*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
 ExecStart=/usr/local/bin/ntopng /run/ntopng.conf
 ExecStopPost=-/bin/rm -rf /run/ntopng.conf
 Restart=on-abnormal

--- a/packages/etc/systemd/system/ntopng.service.in
+++ b/packages/etc/systemd/system/ntopng.service.in
@@ -5,7 +5,7 @@ Wants=@SERVICE_REQUIRES@
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c '/bin/sed "/^-e$\\|-G.*\\|--daemon.*\\|--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
+ExecStartPre=/bin/sh -c '/bin/sed "/^[ \t]*-e$\\|^[ \t]*-G.*\\|--daemon.*\\|^[ \t]*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
 ExecStart=/usr/local/bin/ntopng /run/ntopng.conf
 ExecStopPost=-/bin/rm -rf /run/ntopng.conf
 Restart=on-abnormal

--- a/packages/etc/systemd/system/ntopng.service.in
+++ b/packages/etc/systemd/system/ntopng.service.in
@@ -5,7 +5,7 @@ Wants=@SERVICE_REQUIRES@
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c '/bin/sed "/^[ \t]*-e$\\|^[ \t]*-G.*\\|--daemon.*\\|^[ \t]*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
+ExecStartPre=/bin/sh -c '/bin/sed "/^[ \t]*-e$\\|^[ \t]*-G.*\\|^[ \t]*--daemon.*\\|^[ \t]*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
 ExecStart=/usr/local/bin/ntopng /run/ntopng.conf
 ExecStopPost=-/bin/rm -rf /run/ntopng.conf
 Restart=on-abnormal

--- a/packages/etc/systemd/system/ntopng.service.in
+++ b/packages/etc/systemd/system/ntopng.service.in
@@ -5,7 +5,7 @@ Wants=@SERVICE_REQUIRES@
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c '/bin/sed "/-e.*$\\|-G.*\\|--daemon.*\\|--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
+ExecStartPre=/bin/sh -c '/bin/sed "/^-e$\\|-G.*\\|--daemon.*\\|--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
 ExecStart=/usr/local/bin/ntopng /run/ntopng.conf
 ExecStopPost=-/bin/rm -rf /run/ntopng.conf
 Restart=on-abnormal

--- a/packages/etc/systemd/system/ntopng.service.in
+++ b/packages/etc/systemd/system/ntopng.service.in
@@ -5,7 +5,7 @@ Wants=@SERVICE_REQUIRES@
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c '/bin/sed "/^[ \t]*-e$\\|^[ \t]*-G.*\\|--daemon.*\\|^[ \t]*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
+ExecStartPre=/bin/sh -c '/bin/sed "/^\s*-e$\\|^\s*-G.*\\|--daemon.*\\|^\s*--pid.*/s/^/#/" /etc/ntopng/ntopng.conf > /run/ntopng.conf'
 ExecStart=/usr/local/bin/ntopng /run/ntopng.conf
 ExecStopPost=-/bin/rm -rf /run/ntopng.conf
 Restart=on-abnormal


### PR DESCRIPTION
Fixes issue with commenting out matching on any string containing -e (eg. --enable-user-scripts) and instead anchors it at the beginning of the string, with no wildcards: Matches on "-e" in string only.