### PR TITLE
autogen.sh: portability and clean-up

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -27,7 +27,16 @@ PRO_GIT_RELEASE=""
 PRO_GIT_DATE=""
 fi
 
-cat configure.seed | sed "s/@VERSION@/$VERSION/g" | sed "s/@SHORT_VERSION@/$SHORT_VERSION/g" | sed "s/@GIT_TAG@/$GIT_TAG/g" | sed "s/@GIT_DATE@/$GIT_DATE/g" | sed "s/@GIT_RELEASE@/$GIT_RELEASE/g" | sed "s/@GIT_BRANCH@/$GIT_BRANCH/g"  | sed "s/@PRO_GIT_RELEASE@/$PRO_GIT_RELEASE/g" | sed "s/@PRO_GIT_DATE@/$PRO_GIT_DATE/g" > configure.ac
+cat configure.seed | sed \
+    -e "s/@VERSION@/$VERSION/g" \
+    -e "s/@SHORT_VERSION@/$SHORT_VERSION/g" \
+    -e "s/@GIT_TAG@/$GIT_TAG/g" \
+    -e "s/@GIT_DATE@/$GIT_DATE/g" \
+    -e "s/@GIT_RELEASE@/$GIT_RELEASE/g" \
+    -e "s/@GIT_BRANCH@/$GIT_BRANCH/g" \
+    -e "s/@PRO_GIT_RELEASE@/$PRO_GIT_RELEASE/g" \
+    -e "s/@PRO_GIT_DATE@/$PRO_GIT_DATE/g" \
+    > configure.ac
 
 rm -f config.h config.h.in *~ #*
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 TODAY=`date +%y%m%d`
-NOW=`date +%s`
 MAJOR_RELEASE="3"
 MINOR_RELEASE="3"
 SHORT_VERSION="$MAJOR_RELEASE.$MINOR_RELEASE"

--- a/autogen.sh
+++ b/autogen.sh
@@ -7,7 +7,7 @@ MINOR_RELEASE="3"
 SHORT_VERSION="$MAJOR_RELEASE.$MINOR_RELEASE"
 VERSION="$SHORT_VERSION.$TODAY"
 
-if test -d ".git"; then :
+if test -d ".git"; then
 GIT_TAG=`git rev-parse HEAD`
 GIT_DATE=`date +%Y%m%d`
 GIT_RELEASE="$GIT_TAG:$GIT_DATE"
@@ -18,7 +18,7 @@ GIT_DATE=`date`
 GIT_BRANCH=""
 fi
 
-if test -d "pro"; then :
+if test -d "pro"; then
 PRO_GIT_RELEASE=`cd pro; git log --pretty=oneline | wc -l`
 PRO_GIT_RELEASE=${PRO_GIT_RELEASE//[[:blank:]]/}
 PRO_GIT_DATE=`cd pro; git log --pretty=medium -1 | grep "^Date:"|cut -d " " -f 4-`

--- a/autogen.sh
+++ b/autogen.sh
@@ -29,7 +29,7 @@ fi
 
 cat configure.seed | sed "s/@VERSION@/$VERSION/g" | sed "s/@SHORT_VERSION@/$SHORT_VERSION/g" | sed "s/@GIT_TAG@/$GIT_TAG/g" | sed "s/@GIT_DATE@/$GIT_DATE/g" | sed "s/@GIT_RELEASE@/$GIT_RELEASE/g" | sed "s/@GIT_BRANCH@/$GIT_BRANCH/g"  | sed "s/@PRO_GIT_RELEASE@/$PRO_GIT_RELEASE/g" | sed "s/@PRO_GIT_DATE@/$PRO_GIT_DATE/g" > configure.ac
 
-/bin/rm -f config.h config.h.in *~ #*
+rm -f config.h config.h.in *~ #*
 
 echo "Wait please..."
 autoreconf -if

--- a/autogen.sh
+++ b/autogen.sh
@@ -21,7 +21,7 @@ fi
 if test -d "pro"; then
 PRO_GIT_RELEASE=`cd pro; git log --pretty=oneline | wc -l`
 PRO_GIT_RELEASE=${PRO_GIT_RELEASE//[[:blank:]]/}
-PRO_GIT_DATE=`cd pro; git log --pretty=medium -1 | grep "^Date:"|cut -d " " -f 4-`
+PRO_GIT_DATE=`cd pro; git log --pretty=medium -1 | grep "^Date:" | cut -d " " -f 4-`
 else
 PRO_GIT_RELEASE=""
 PRO_GIT_DATE=""


### PR DESCRIPTION
Mainly, this changes "/bin/rm" to "rm", to help building with Nix. But I ended up doing a bit of clean-up as well. (Separate commits.)