### PR TITLE
feat(fritzdump.sh): add sanity checks, user feedback, username argument

### DIFF
--- a/tools/fritzdump.sh
+++ b/tools/fritzdump.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
-# The is the address of the router
-FRITZIP=http://192.168.2.1
-FRITZPWD=$1
+# This is the address of the router
+FRITZIP=http://fritz.box
+
 # This is the WAN interface
-#IFACE="2-0"
+IFACE="2-0"
 
 # Lan Interface
-IFACE="1-lan"
+#IFACE="1-lan"
 
-FRITZUSER=""
+# Required: You must create & switch your Fritz!Box to usernamed-based login authentification!
+FRITZUSER=$1
+FRITZPWD=$2
+
 SIDFILE="/tmp/fritz.sid"
 
+if [ -z "$FRITZPWD" ] || [ -z "$FRITZUSER" ]  ; then echo "Username/Password empty. Usage: $0 <username> <password>" ; exit 1; fi
+
+echo "Trying to login into $FRITZIP as user $FRITZUSER"
 
 if [ ! -f $SIDFILE ]; then
   touch $SIDFILE
@@ -19,22 +25,27 @@ fi
 
 SID=$(cat $SIDFILE)
 
+# Request challenge token from Fritz!Box
 CHALLENGE=$(curl -k -s $FRITZIP/login_sid.lua |  grep -o "<Challenge>[a-z0-9]\{8\}" | cut -d'>' -f 2)
+
+# Very proprieatry way of AVM: Create a authentication token by hashing challenge token with password
 HASH=$(perl -MPOSIX -e '
     use Digest::MD5 "md5_hex";
     my $ch_Pw = "$ARGV[0]-$ARGV[1]";
-    $ch_Pw =~ s/(.)/$1 . chr(0)/eg; 
-    my $md5 = lc(md5_hex($ch_Pw)); 
+    $ch_Pw =~ s/(.)/$1 . chr(0)/eg;
+    my $md5 = lc(md5_hex($ch_Pw));
     print $md5;
   ' -- "$CHALLENGE" "$FRITZPWD")
   curl -k -s "$FRITZIP/login_sid.lua" -d "response=$CHALLENGE-$HASH" -d 'username='${FRITZUSER} | grep -o "<SID>[a-z0-9]\{16\}" | cut -d'>' -f 2 > $SIDFILE
 
 SID=$(cat $SIDFILE)
 
-echo "Capturing traffic.." 1>&2 
+# Check for successfull authentification
+if [[ $SID =~ ^0+$ ]] ; then echo "Login failed. Did you create & use explicit Fritz!Box users?" ; exit 1 ; fi
+
+echo "Capturing traffic on Fritz!Box interface $IFACE ..." 1>&2
 
 # In case you want to use tshark instead of ntopng
-#wget --no-check-certificate -qO- $FRITZIP/cgi-bin/capture_notimeout?ifaceorminor=$IFACE\&snaplen=\&capture=Start\&sid=$SID | /usr/local/bin/tshark -r -
+#wget --no-check-certificate -qO- $FRITZIP/cgi-bin/capture_notimeout?ifaceorminor=$IFACE\&snaplen=\&capture=Start\&sid=$SID | /usr/bin/tshark -r -
 
 wget --no-check-certificate -qO- $FRITZIP/cgi-bin/capture_notimeout?ifaceorminor=$IFACE\&snaplen=\&capture=Start\&sid=$SID | ntopng -i -
-


### PR DESCRIPTION
This patch changes the CLI interface from `fritzdump.sh <pass>` to `fritzdump.sh <user> <pass>`

It also changes a few settings to more sane defaults, which should enable that the script can run out of the box in many cases

1. the router IP to the router is now resolved via http://fritz.box
2. the default monitored interface is changed to to the WWAN interface 2-0