### PR TITLE
Fixed default path to ndpi include files.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -110,7 +110,7 @@ AC_ARG_WITH(ndpi-includes,
    ])
 
 PKG_CHECK_MODULES([NDPI], [libndpi >= 2.0], [
-   NDPI_INC=`echo $NDPI_CFLAGS | sed -e "s/[ ]*$//"`/libndpi
+   NDPI_INC=`echo $NDPI_CFLAGS | sed -e "s/[ ]*$//"`
    # Use static libndpi library as building against the dynamic library fails
    NDPI_LIB="-Wl,-Bstatic $NDPI_LIBS -Wl,-Bdynamic"
    NDPI_LIB_DEP=


### PR DESCRIPTION
nDPI 2.4ish installs headers in ${includedir}/ndpi/, not
${includedir}/ndpi/libndpi. And, I just issued PRs which fix nDPI's
libndpi.pc file. So, ntopng can just believe the -I it gets from
pkg-config.