### PR TITLE
Fix Mongoose #define-related build failures.

### DIFF
--- a/third-party/mongoose/mongoose.c
+++ b/third-party/mongoose/mongoose.c
@@ -247,7 +247,9 @@ struct pollfd {
 #define mg_rename(x, y) rename(x, y)
 #define mg_sleep(x) usleep((x) * 1000)
 #define ERRNO errno
+#ifndef INVALID_SOCKET
 #define INVALID_SOCKET (-1)
+#endif
 
 /* ntop */
 #if ((ULONG_MAX) == (UINT_MAX))
@@ -270,7 +272,9 @@ struct pollfd {
 #endif
 
 //#define INT64_FMT PRId64
+#ifndef SOCKET
 typedef int SOCKET;
+#endif
 #define WINCDECL
 
 #endif // End of Windows and UNIX specific includes


### PR DESCRIPTION
This fixes the issue raise in #1944 (which was closed without being fixed). The change has already been
picked up by some distributions, such as Arch:

https://aur.archlinux.org/cgit/aur.git/commit/?h=ntopng&id=320514a74f4839d8b6c8a2f32790ff16caba9ee7