### PR TITLE
Fix race condition while building exposed by removing '.NOTPARALLEL:'.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -166,7 +166,7 @@ HEADERS = $(wildcard include/*.h) @PRO_HEADERS@
 
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
-$(TARGET): $(OBJECTS) $(LIBRRDTOOL) Makefile
+$(TARGET): $(OBJECTS) $(LIB_TARGETS) Makefile
 	$(GPP) $(OBJECTS) -Wall $(NLIBS) -o $@
 
 $(LUAJIT_LIB):


### PR DESCRIPTION
In 0b5bbb8 the .NOTPARALLEL directive was removed.

$(TARGET) requires third party library to be compiled before it can start compiling.

Otherwise compilation of ntopng may file because it tries to link to LUAjit before the library has been generated.