### PR TITLE
Fixed custom time series loading

### DIFF
--- a/scripts/lua/modules/timeseries/ts_utils_core.lua
+++ b/scripts/lua/modules/timeseries/ts_utils_core.lua
@@ -2,6 +2,7 @@
 -- (C) 2018 - ntop.org
 --
 
+
 local ts_utils = {}
 
 local ts_common = require "ts_common"
@@ -21,6 +22,7 @@ require "ntop_utils"
 
 package.path = dirs.installdir .. "/scripts/lua/modules/timeseries/drivers/?.lua;" .. package.path
 package.path = dirs.installdir .. "/scripts/lua/modules/timeseries/schemas/?.lua;" .. package.path
+package.path = dirs.installdir .. "/scripts/lua/modules/timeseries/custom/?.lua;" .. package.path
 
 -- ##############################################
 
@@ -92,6 +94,9 @@ function ts_utils.loadSchemas()
   require("ts_minute")
   require("ts_5min")
   require("ts_hour")
+  require("ts_5min_custom")
+  require("ts_minute_custom")
+
 end
 
 function ts_utils.getLoadedSchemas()


### PR DESCRIPTION

This error occurs when ntopng tries to load custom time series schemas:
![Schermata del 2019-03-12 17-29-09](https://user-images.githubusercontent.com/40372400/54376076-87d3ac80-4682-11e9-8e31-7a8063a0e500.png)

Reference to custom time series scripts is missed.