### PR TITLE
Add Dockerfile based on 18.04 LTS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,14 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get -y install wget lsb-release gnupg
+# Pass --build-arg TZ=<YOUR_TZ> when running docker build to override this.
+ARG TZ=America/Los_Angeles
+
+RUN apt-get update && apt-get -y install wget lsb-release gnupg tzdata
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget -O apt-ntop-stable.deb http://apt-stable.ntop.org/18.04/all/apt-ntop-stable.deb && \
 	dpkg -i apt-ntop-stable.deb && rm -f apt-ntop-stable.deb
 RUN apt-get update && apt-get -y install ntopng
-
 RUN echo '#!/usr/bin/env bash\n/etc/init.d/redis-server start && ntopng "$@"' > /tmp/run.sh
 RUN chmod +x /tmp/run.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y install wget lsb-release gnupg
+RUN wget -O apt-ntop-stable.deb http://apt-stable.ntop.org/18.04/all/apt-ntop-stable.deb && \
+	dpkg -i apt-ntop-stable.deb && rm -f apt-ntop-stable.deb
+RUN apt-get update && apt-get -y install ntopng
+
+RUN echo '#!/usr/bin/env bash\n/etc/init.d/redis-server start && ntopng "$@"' > /tmp/run.sh
+RUN chmod +x /tmp/run.sh
+
+ENTRYPOINT ["/tmp/run.sh"]


### PR DESCRIPTION
I wanted a newer environment to run ntopng in since [this](https://github.com/lucaderi/ntopng-docker) was last updated 3 years ago.

I'm running this successfully on my server via systemd:
```
[Unit]
Description=ntopng
Requires=docker.service
After=docker.service

[Service]
Restart=always
ExecStart=/usr/bin/docker run --name ntopng --net=host -t -v /ssd/ntopng:/var/lib/ntopng ntopng -l 1 -w 192.168.1.1:5000 -i enp2s0 -i enp3s0 -i enp5s0
ExecStop=/usr/bin/docker stop ntopng
ExecStopPost=/usr/bin/docker rm ntopng

[Install]
WantedBy=multi-user.target
```

If you think the systemd file is helpful let me know and I can commit a template of it in this MR.