### PR TITLE
Fix typo in IPv4 Multicast MAC Address detection

### DIFF
--- a/include/Mac.h
+++ b/include/Mac.h
@@ -171,7 +171,7 @@ class Mac : public GenericHashEntry, public SerializableElement {
     if(
        ((mac[0] == 0x33) && (mac[1] == 0x33))
        ||
-       ((mac[0] == 0x01) && (mac[1] == 0x00) && (mac[1] == 0x5E))
+       ((mac[0] == 0x01) && (mac[1] == 0x00) && (mac[2] == 0x5E))
        )
       return(true);
     else


### PR DESCRIPTION
Cross-compiling ntopng for OpenWRT (musl) produces the following warning:

```
aarch64-openwrt-linux-musl-g++ -g -Wall -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3 -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/include -I/usr/local/include -I /opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/hiredis -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/mongoose -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include/json-c  -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include/ndpi -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include/ndpi/../lib/third_party/include -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/lua-5.3.5/src -DDONT_USE_LUAJIT -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/rrdtool-1.4.8/src/ -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/zeromq-4.1.3/include -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mysql -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mysql/.. -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/include -I/opt/openwrt.git/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.4.0_musl/usr/include -I/opt/openwrt.git/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.4.0_musl/include/fortify -I/opt/openwrt.git/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.4.0_musl/include  -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3 -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/include -I/usr/local/include -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/http-client-c/src/ -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include -I/usr/include/openssl  -DDATA_DIR='"/usr/share"' -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/libgeohash -I/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/third-party/patricia  -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -iremap/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3:ntopng-3 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/usr/include -I/opt/openwrt.git/staging_dir/target-aarch64_cortex-a53_musl/include -I/opt/openwrt.git/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.4.0_musl/usr/include -I/opt/openwrt.git/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.4.0_musl/include/fortify -I/opt/openwrt.git/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.4.0_musl/include  -c src/ElasticSearch.cpp -o src/ElasticSearch.o
In file included from /opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/include/ntop_includes.h:332:0,
                 from src/ElasticSearch.cpp:22:
/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/include/Mac.h: In member function 'bool Mac::isMulticast()':
/opt/openwrt.git/build_dir/target-aarch64_cortex-a53_musl/ntopng-3/include/Mac.h:174:65: warning: 'and' of mutually exclusive equal-tests is always 0
        ((mac[0] == 0x01) && (mac[1] == 0x00) && (mac[1] == 0x5E))
```

Using the following patch seems to silence the compiler:
```diff
diff -Naur ntopng.orig/include/Mac.h ntopng/include/Mac.h
--- ntopng.orig/include/Mac.h	2019-06-07 20:59:32.000000000 +0200
+++ ntopng/include/Mac.h	2019-06-09 10:23:33.564000000 +0200
@@ -171,7 +171,7 @@
     if(
        ((mac[0] == 0x33) && (mac[1] == 0x33))
        ||
-       ((mac[0] == 0x01) && (mac[1] == 0x00) && (mac[1] == 0x5E))
+       ((mac[0] == 0x01) && (mac[1] == 0x00) && (mac[2] == 0x5E))
        )
       return(true);
     else
```