### PR TITLE
Implement reusable lua engine

### DIFF
--- a/include/LuaEngine.h
+++ b/include/LuaEngine.h
@@ -76,7 +76,7 @@ class LuaEngine {
    *
    * @return 0 if the script has been executed successfully.
    */
-  int run_script(char *script_path, NetworkInterface *iface, bool load_only = false, time_t deadline = 0);
+  int run_script(char *script_path, NetworkInterface *iface, bool load_only = false, time_t deadline = 0, bool no_pcall = false);
 
   /**
    * @brief Handling of request info of script.

--- a/include/LuaReusableEngine.h
+++ b/include/LuaReusableEngine.h
@@ -1,6 +1,6 @@
 /*
  *
- * (C) 2013-19 - ntop.org
+ * (C) 2019 - ntop.org
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,26 +19,27 @@
  *
  */
 
-#ifndef _PERIODIC_ACTIVITIES_H_
-#define _PERIODIC_ACTIVITIES_H_
+#ifndef _LUA_REUSABLE_ENGINE_H_
+#define _LUA_REUSABLE_ENGINE_H_
 
 #include "ntop_includes.h"
 
-class PeriodicActivities {
+class LuaReusableEngine {
  private:
-  ThreadedActivity *activities[CONST_MAX_NUM_THREADED_ACTIVITIES];
-  u_int16_t num_activities;
-  ThreadPool *high_priority_pool, *standard_priority_pool, *no_priority_pool;
-  
+  LuaEngine *vm;
+  NetworkInterface *iface;
+  char *script_path;
+  int reload_interval;
+  time_t next_reload;
+
+  void reloadVm(time_t now);
+
  public:
-  PeriodicActivities();
-  ~PeriodicActivities();
+  LuaReusableEngine(const char *_script_path, NetworkInterface *_iface, int _reload_interval);
+  ~LuaReusableEngine();
 
-  void startPeriodicActivitiesLoop();
-  void sendShutdownSignal();
-
-  void lua(NetworkInterface *iface, lua_State *vm);
-  void reloadVMs();
+  bool pcall(time_t deadline);
+  inline void setNextVmReload(time_t t) { next_reload = t; }
 };
 
-#endif /* _PERIODIC_ACTIVITIES_H_ */
+#endif

--- a/include/Ntop.h
+++ b/include/Ntop.h
@@ -80,6 +80,10 @@ class Ntop {
   std::set<std::string> *new_malicious_ja3, *malicious_ja3, *malicious_ja3_shadow;
   FifoStringsQueue *sqlite_alerts_queue, *alerts_notifications_queue, *internal_alerts_queue;
 
+#ifdef __linux__
+  int inotify_fd;
+#endif
+
 #ifdef NTOPNG_PRO
 #ifndef WIN32
   NagiosManager *nagios_manager;

--- a/include/ThreadedActivity.h
+++ b/include/ThreadedActivity.h
@@ -37,10 +37,15 @@ class ThreadedActivity {
   bool exclude_pcap_dump_interfaces;
   bool thread_started;
   bool systemTaskRunning;
+  bool reuse_vm;
   bool *interfaceTasksRunning;
   Mutex m;
   ThreadPool *pool;
   ThreadedActivityStats **threaded_activity_stats;
+  Mutex vms_mutex;
+
+  /* iface -> engine */
+  std::map<std::string, LuaReusableEngine*> vms;
 
   void periodicActivityBody();
   void aperiodicActivityBody();
@@ -49,13 +54,15 @@ class ThreadedActivity {
   void setInterfaceTaskRunning(NetworkInterface *iface, bool running);
   bool isInterfaceTaskRunning(NetworkInterface *iface);
   void updateThreadedActivityStats(NetworkInterface *iface, u_long latest_duration);
-  
+  void reloadVm(const char *ifname);
+
  public:
   ThreadedActivity(const char* _path,		   
 		   u_int32_t _periodicity_seconds = 0,
 		   bool _align_to_localtime = false,
 		   bool _exclude_viewed_interfaces = false,
 		   bool _exclude_pcap_dump_interfaces = false,
+       bool _reuse_vm = false,
 		   ThreadPool* _pool = NULL);
   ~ThreadedActivity();
 
@@ -67,6 +74,7 @@ class ThreadedActivity {
   inline void shutdown()      { terminating = true; };
   void terminateEnqueueLoop();
   bool isTerminating();
+  void setNextVmReload(time_t when);
 
   void run();
 

--- a/include/ntop_includes.h
+++ b/include/ntop_includes.h
@@ -286,6 +286,7 @@ using namespace std;
 #include "AlertsQueue.h"
 #include "NetworkInterfaceTsPoint.h"
 #include "LuaEngine.h"
+#include "LuaReusableEngine.h"
 #include "AlertCheckLuaEngine.h"
 #include "FlowAlertCheckLuaEngine.h"
 #include "SyslogLuaEngine.h"

--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -11626,7 +11626,7 @@ static int post_iterator(void *cls,
 /*
   Run a Lua script from within ntopng (no HTTP GUI)
 */
-int LuaEngine::run_script(char *script_path, NetworkInterface *iface, bool load_only, time_t deadline) {
+int LuaEngine::run_script(char *script_path, NetworkInterface *iface, bool load_only, time_t deadline, bool no_pcall) {
   int rc = 0;
 
   if(!L) return(-1);
@@ -11654,7 +11654,7 @@ int LuaEngine::run_script(char *script_path, NetworkInterface *iface, bool load_
 #endif
       rc = !load_only ? luaL_dofile(L, script_path) : luaL_loadfile(L, script_path);
 
-    if(rc == 0 && load_only)
+    if(rc == 0 && load_only && !no_pcall)
       rc = lua_pcall(L, 0, 0, 0); /* Prevents loaded scripts from failing silently by showing possible syntax errors */
 
     if(rc != 0) {

--- a/src/LuaReusableEngine.cpp
+++ b/src/LuaReusableEngine.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ * (C) 2019 - ntop.org
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ */
+
+#include "ntop_includes.h"
+
+/* ******************************* */
+
+LuaReusableEngine::LuaReusableEngine(const char *_script_path, NetworkInterface *_iface, int _reload_interval) {
+  script_path = strdup(_script_path);
+  reload_interval = _reload_interval;
+  iface = _iface;
+  vm = NULL;
+  next_reload = 0;
+}
+
+/* ******************************* */
+
+LuaReusableEngine::~LuaReusableEngine() {
+  if(script_path) free(script_path);
+  if(vm) delete vm;
+}
+
+/* ******************************* */
+
+void LuaReusableEngine::reloadVm(time_t now) {
+  if(vm) {
+    delete vm;
+    vm = NULL;
+  }
+
+  try {
+    vm = new LuaEngine();
+  } catch(std::bad_alloc& ba) {
+    static bool oom_warning_sent = false;
+
+    if(!oom_warning_sent) {
+      ntop->getTrace()->traceEvent(TRACE_ERROR, "[ThreadedActivity] Unable to start a Lua interpreter.");
+      oom_warning_sent = true;
+    }
+
+    return;
+  }
+
+  vm->run_script(script_path, iface, true /* load only */, 0, true /* no_pcall */);
+  next_reload = now + reload_interval;
+}
+
+/* ******************************* */
+
+bool LuaReusableEngine::pcall(time_t deadline) {
+  time_t now = time(NULL);
+  int top;
+
+  if((vm == NULL) || (now >= next_reload))
+    reloadVm(now);
+
+  if(vm == NULL)
+    return(false);
+
+  if(deadline) {
+    lua_pushinteger(vm->getState(), deadline);
+    lua_setglobal(vm->getState(), "deadline");
+  }
+
+  top = lua_gettop(vm->getState());
+
+  /* Copy the lua_chunk to be able to run it again next time */
+  lua_pushvalue(vm->getState(), -1);
+
+  /* Perform the actual call */
+  ntop->getTrace()->traceEvent(TRACE_DEBUG, "%p: pcall(%s, %s)", this, script_path, iface->get_name());
+  lua_pcall(vm->getState(), 0, 0, 0);
+
+  /* Reset the stack */
+  lua_settop(vm->getState(), top);
+
+  return(true);
+}

--- a/src/PeriodicActivities.cpp
+++ b/src/PeriodicActivities.cpp
@@ -28,6 +28,7 @@ typedef struct _activity_descr {
   bool align_to_localtime;  
   bool exclude_viewed_interfaces;
   bool exclude_pcap_dump_interfaces;
+  bool reuse_vm;
 } activity_descr;
 
 /* ******************************************* */
@@ -96,7 +97,7 @@ void PeriodicActivities::startPeriodicActivitiesLoop() {
 #endif
   ThreadedActivity *startup_activity;
   u_int8_t num_threads = DEFAULT_THREAD_POOL_SIZE;
-    
+
   ntop->getTrace()->traceEvent(TRACE_NORMAL, "Started periodic activities loop...");
 
   if(stat(ntop->get_callbacks_dir(), &buf) != 0) {
@@ -129,20 +130,20 @@ void PeriodicActivities::startPeriodicActivitiesLoop() {
   no_priority_pool       = new ThreadPool(false, num_threads);
   
   static activity_descr ad[] = {
-    { SECOND_SCRIPT_PATH,             1, standard_priority_pool, false, false, true  },
-    { HT_STATE_UPDATE_SCRIPT_PATH,    5, high_priority_pool,     false, true,  false },
-    { STATS_UPDATE_SCRIPT_PATH,       5, standard_priority_pool, false, false, true  },
-    { MINUTE_SCRIPT_PATH,            60, no_priority_pool,       false, false, true  },
-    { FIVE_MINUTES_SCRIPT_PATH,     300, no_priority_pool,       false, false, true  },
-    { HOURLY_SCRIPT_PATH,          3600, no_priority_pool,       false, false, true  },
-    { DAILY_SCRIPT_PATH,          86400, no_priority_pool,       true,  false, true  },
-    { HOUSEKEEPING_SCRIPT_PATH,       3, standard_priority_pool, false, false, true  },
-    { DISCOVER_SCRIPT_PATH,           5, no_priority_pool,       false, false, true  },
-    { TIMESERIES_SCRIPT_PATH,         5, standard_priority_pool, false, false, true  },
+    { SECOND_SCRIPT_PATH,             1, standard_priority_pool, false, false, true,  true  },
+    { HT_STATE_UPDATE_SCRIPT_PATH,    5, high_priority_pool,     false, true,  false, true  },
+    { STATS_UPDATE_SCRIPT_PATH,       5, standard_priority_pool, false, false, true,  true  },
+    { MINUTE_SCRIPT_PATH,            60, no_priority_pool,       false, false, true,  false },
+    { FIVE_MINUTES_SCRIPT_PATH,     300, no_priority_pool,       false, false, true,  false },
+    { HOURLY_SCRIPT_PATH,          3600, no_priority_pool,       false, false, true,  false },
+    { DAILY_SCRIPT_PATH,          86400, no_priority_pool,       true,  false, true,  false },
+    { HOUSEKEEPING_SCRIPT_PATH,       3, standard_priority_pool, false, false, true,  true  },
+    { DISCOVER_SCRIPT_PATH,           5, no_priority_pool,       false, false, true,  true  },
+    { TIMESERIES_SCRIPT_PATH,         5, standard_priority_pool, false, false, true,  true  },
 #ifdef HAVE_NEDGE
-    { PINGER_SCRIPT_PATH,             5, no_priority_pool,       false, false, true  },
+    { PINGER_SCRIPT_PATH,             5, no_priority_pool,       false, false, true,  false },
 #endif
-    { NULL, 0, NULL, false, false }
+    { NULL, 0, NULL, false, false, false, false }
   };
 
   ntop->getTrace()->traceEvent(TRACE_NORMAL, "Each periodic activity script will use %u threads", num_threads);
@@ -155,6 +156,7 @@ void PeriodicActivities::startPeriodicActivitiesLoop() {
 						d->align_to_localtime,
 						d->exclude_viewed_interfaces,
 						d->exclude_pcap_dump_interfaces,
+            d->reuse_vm,
 						d->pool);
     if(ta) {
       activities[num_activities++] = ta;
@@ -163,4 +165,13 @@ void PeriodicActivities::startPeriodicActivitiesLoop() {
 
     d++;
   }
+}
+
+/* ******************************************* */
+
+void PeriodicActivities::reloadVMs() {
+  time_t next_reload = time(NULL) + 1;
+
+  for(int i = 0; i < num_activities; i++)
+    activities[i]->setNextVmReload(next_reload);
 }

--- a/src/ThreadedActivity.cpp
+++ b/src/ThreadedActivity.cpp
@@ -242,7 +242,9 @@ void ThreadedActivity::runScript(char *script_path, NetworkInterface *iface, tim
 
     vms_mutex.unlock(__FILE__, __LINE__);
 
+    gettimeofday(&begin, NULL);
     engine->pcall(deadline);
+    gettimeofday(&end, NULL);
   } else {
     try {
       l = new LuaEngine();


### PR DESCRIPTION
The same Lua vm is now reused. After 5 minutes the vm is destroyed and reloaded to prevent memory to grow too much. inotify is used to detected changes in the filesystem (partially implemented, must implement a recursive watch)

This reduces periodic scripts execution ticks by a 10x factor. On my machine this also reduced average cpu usage from 10% to 3% (tested with `top -p $(pgrep ntopng) -d 5`)