### PR TITLE
FritzBox: Add info on usage with password-only auth

### DIFF
--- a/doc/README.fritzbox
+++ b/doc/README.fritzbox
@@ -21,9 +21,7 @@ Example usage:
 ntopng/tools/fritzdump.sh <username> <password>
 ```
 
-*NOTE:* Please enable username-based authentification instead of the default
-password-only authentification. This setting can be found in the FRITZ!Box Web-UI
-at _"System > FRITZ!Box-Benutzer > Anmeldung im Heimnetz"._
+*NOTE:* If you use password-only authentification pass "dslf-config" as username
 
 As you can see in the script, it will connect to the Fritz!Box via http://fritz.box,
 authenticate with the user and password you passed and capture the traffic on the

--- a/tools/fritzdump.sh
+++ b/tools/fritzdump.sh
@@ -9,7 +9,7 @@ IFACE="2-0"
 # Lan Interface
 #IFACE="1-lan"
 
-# Required: You must create & switch your Fritz!Box to usernamed-based login authentification!
+# If you use password-only authentication use 'dslf-config' as username.
 FRITZUSER=$1
 FRITZPWD=$2
 


### PR DESCRIPTION
The FritzBox interface works with an implicit user called dlsf-config, so it would be easier for users to stay with password-only auth and just enter dslf-config as username.
I updated this in fritzdump.sh and README.fritzbox