### PR TITLE
Disable buttons on row after a request

### DIFF
--- a/httpdocs/js/config_callbacks/config-list-utils.js
+++ b/httpdocs/js/config_callbacks/config-list-utils.js
@@ -216,6 +216,8 @@ $(document).ready(function() {
             $("#applied-input").val(config_targets.map(d => d.key.toString()).join(','))
         }
 
+        // hide previous errors
+        $("#apply-error").hide();
 
         $("#apply-name").html(`<b>${config_name}</b>`);
         $("#applied-modal form").off("submit");
@@ -378,6 +380,7 @@ $(document).ready(function() {
         const {config_id, config_name} = get_configuration_data($config_table, $(this));
 
         $("#delete-name").html(`<b>${config_name}</b>`)
+        $("#delete-error").hide(); 
 
         $("#delete-modal form").off('submit');
         $("#btn-confirm-delete").off("click").click(function(e) {

--- a/httpdocs/js/config_callbacks/scripts-list-utils.js
+++ b/httpdocs/js/config_callbacks/scripts-list-utils.js
@@ -141,6 +141,9 @@
                           }
                        })
 
+                       // disable all buttons to prevent more requests
+                       $("#scripts-config input[name$='-check']").attr("disabled", "").parent().addClass("disabled");
+
                        $.post(`${http_prefix}/lua/edit_user_script_config.lua`, {
                           script_subdir: script_subdir,
                           script_key: row.key,
@@ -153,6 +156,10 @@
                        })
                        .fail(({status, statusText}) => {
                           check_status_code(status, statusText, null);
+                       })
+                       .always(() => {
+                          // re eanble buttons
+                          $("#scripts-config input[name$='-check']").removeAttr("disabled").parent().removeClass("disabled");
                        })
 
                     });

--- a/httpdocs/js/config_callbacks/scripts-list-utils.js
+++ b/httpdocs/js/config_callbacks/scripts-list-utils.js
@@ -141,6 +141,9 @@
                           }
                        })
 
+                       // hide alert
+                       $("#alert-row-buttons").hide();
+
                        // disable all buttons to prevent more requests
                        $("#scripts-config input[name$='-check']").attr("disabled", "").parent().addClass("disabled");
 
@@ -152,12 +155,24 @@
                           confset_id: confset_id
                        })
                        .done((d, status, xhr) => {
-                          location.reload();
+
+                          if (!d.success) {
+                              $("#alert-row-buttons").text(data.error).removeClass('d-none').show();
+                              // update csrf
+                              csrf_toggle_buttons = d.csrf;
+                          }
+                          
+                          if (d.success) location.reload();
+
                        })
                        .fail(({status, statusText}) => {
                           check_status_code(status, statusText, null);
-                       })
-                       .always(() => {
+
+                          // if the csrf has expired 
+                          if (status == 200) {
+                              $("#alert-row-buttons").text(`${i18n.expired_csrf}`).removeClass('d-none').show();
+                          }
+
                           // re eanble buttons
                           $("#scripts-config input[name$='-check']").removeAttr("disabled").parent().removeClass("disabled");
                        })
@@ -272,6 +287,9 @@
 
           // destructure gui and hooks from data
           const {gui, hooks} = data;
+
+          // hide previous error
+          $("#apply-error").hide();
 
           const build_gui = (gui, hooks) => {
 
@@ -445,8 +463,16 @@
               .done((d, status, xhr) => {
 
                  if (check_status_code(xhr.status, xhr.statusText, $error_label)) return;
+
+                 if (!d.success) {
+
+                     $error_label.text(d.error).show();
+                     // update token
+                     csrf_edit_config = d.csrf;
+                 }
+
                  // if the operation was successfull then reload the page
-                 location.reload();
+                 if (d.success) location.reload();
               })
               .fail(({status, statusText}) => {
 

--- a/httpdocs/templates/script_list.html
+++ b/httpdocs/templates/script_list.html
@@ -29,6 +29,8 @@
   </nav>
   <div class="row">
     <div class="col-md-12 col-lg-12 mt-3">
+      <div class="alert alert-danger d-none" id='alert-row-buttons' role="alert">
+      </div>
       <table
         id="scripts-config"
         class="table w-100 table-striped table-hover table-bordered mt-3">
@@ -54,8 +56,8 @@
 
 const confset_id = {{ script_list.confset_id }};
 const script_subdir = "{{ script_list.script_subdir }}";
-const csrf_toggle_buttons = "{{ ntop.getRandomCSRFValue() }}";
-const csrf_edit_config = "{{ ntop.getRandomCSRFValue() }}";
+let csrf_toggle_buttons = "{{ ntop.getRandomCSRFValue() }}";
+let csrf_edit_config = "{{ ntop.getRandomCSRFValue() }}";
 
 i18n.are_you_sure = '{{ i18n("scripts_list.are_you_sure", {}) }}'
 i18n.all = '{{ i18n("all", {}) }}'


### PR DESCRIPTION
Now on `script_list.html` when a user make a toggle request the buttons will be disabled in the entire script table. Furthermore now there is a check if the csrf expires on the same page.