### PR TITLE
fix for issue #3322

### DIFF
--- a/scripts/lua/edit_scripts_configsets.lua
+++ b/scripts/lua/edit_scripts_configsets.lua
@@ -99,6 +99,7 @@ elseif(action == "set_targets") then
 
     if not success then
       result.error = err
+      result.csrf = ntop.getRandomCSRFValue()
     end
   else
     -- Validation error


### PR DESCRIPTION
now when a request for 'apply to' fails a new csrf token is sent, thus a user can retry to edit the configuration set