### PR TITLE
[WIN32] Close the socket properly

### DIFF
--- a/src/NetworkDiscovery.cpp
+++ b/src/NetworkDiscovery.cpp
@@ -79,7 +79,7 @@ NetworkDiscovery::NetworkDiscovery(NetworkInterface *_iface) {
 
 NetworkDiscovery::~NetworkDiscovery() {
   if(pd)             pcap_close(pd);
-  if(udp_sock != -1) close(udp_sock);
+  if(udp_sock != -1) closesocket(udp_sock);
 
   if(has_bpf_filter) pcap_freecode(&fcode);
 }


### PR DESCRIPTION
In Windows, when you call `close (fd)` on an invalid `fd`, the invalid-parameter handler kicks in. 
A socket-`fd` should off-course be closed using `closesocket (s)` (which is a macro for non-`WIN32` targets).
