### PR TITLE
[WIN32] Fix pthread_mutex_init() implementation

### DIFF
--- a/src/ntop_win32.c
+++ b/src/ntop_win32.c
@@ -65,8 +65,9 @@ int pthread_join (pthread_t threadId, void **_value_ptr) {
 
 /* ************************************ */
 
-int pthread_mutex_init(pthread_mutex_t *mutex, char* notused) {
+int pthread_mutex_init(pthread_mutex_t *mutex, void* notused) {
   (*mutex) = CreateMutex(NULL, FALSE, NULL);
+  (void) notused;	
   return(0);
 }
 


### PR DESCRIPTION
`pthread_mutex_init()` is prototyped with `void * notused` as the last parameter.
Hence let the implementation have the same. 

(this goes to show hardly anybody cares about NtopNG for Windows).