### PR TITLE
Illegal C++11 narrowing

### DIFF
--- a/src/NetworkDiscovery.cpp
+++ b/src/NetworkDiscovery.cpp
@@ -683,7 +683,7 @@ void NetworkDiscovery::discover(lua_State* vm, u_int timeout) {
   struct sockaddr_in sin;
   char msg[1024];
   u_int16_t ssdp_port = htons(1900);
-  struct timeval tv = { (time_t)timeout /* sec */, 0 };
+  struct timeval tv;
   fd_set fdset;
 
   char *ifname  = iface->altDiscoverableName();
@@ -696,7 +696,10 @@ void NetworkDiscovery::discover(lua_State* vm, u_int timeout) {
   if(udp_sock == -1) return;
 
   if(timeout < 1) timeout = 1;
-
+	
+  tv.tv_sec = timeout;
+  tv.tv_usec = 0;
+	
   /* SSDP */
   sin.sin_addr.s_addr = inet_addr("239.255.255.250"), sin.sin_family = AF_INET, sin.sin_port = ssdp_port;
 


### PR DESCRIPTION
With clang-cl, the current code on Windows:
```
  struct timeval tv = { (time_t)timeout /* sec */, 0 };
```
gives this error:
```
NetworkDiscovery.cpp(686,25): error: non-constant-expression cannot be narrowed
from type 'time_t' (aka 'long long') to 'long' in initializer list [-Wc++11-narrowing]
  struct timeval tv = { (time_t)timeout /* sec */, 0 };
                        ^~~~~~~~~~~~~~~
```

Since Winsock (for historic reasons) declares a `tv_sec` as a `long`) and a `time_t` as a 64-bit `__int64`.
To avoid this issue I was forced use build with `-D_USE_32BIT_TIME_T_`, but that seemed completely wrong.
Hence this patch.

Besides, I gather the `timeout` for `select()` should be at least 1 sec. 