### PR TITLE
Cast argument for pcap_sendpacket()

### DIFF
--- a/src/NetworkDiscovery.cpp
+++ b/src/NetworkDiscovery.cpp
@@ -746,7 +746,7 @@ void NetworkDiscovery::discover(lua_State* vm, u_int timeout) {
     for(i=0; query_list[i] != NULL; i++) {
       u_int16_t len = buildMDNSDiscoveryDatagram(query_list[i], sender_ip, sender_mac, msg, sizeof(msg));
 
-      if(pcap_sendpacket(pd, msg, len) == -1)
+      if(pcap_sendpacket(pd, (const u_char *)&msg, len) == -1)
 	ntop->getTrace()->traceEvent(TRACE_ERROR, "Send error [%d/%s]", errno, strerror(errno));
       else
 	ntop->getTrace()->traceEvent(TRACE_NORMAL, "Sent MDNS request [%s][len: %u]", query_list[i], len);


### PR DESCRIPTION
Fix this C++ error:
```
NetworkDiscovery.cpp(749): 
error C2664: 'int pcap_sendpacket(pcap_t *,const u_char *,int)': cannot convert argument 2 from
'char [1024]' to 'const u_char *'
```

Got this error using MSVC-2019. But clang-cl is equally picky.

(I guess `-DMDNS_MULTICAST_DISCOVERY` is seldom used?)