### PR TITLE
correct typo on redis_monitor.lua

### DIFF
--- a/scripts/plugins/redis_monitor/user_scripts/system/redis_monitor.lua
+++ b/scripts/plugins/redis_monitor/user_scripts/system/redis_monitor.lua
@@ -97,7 +97,7 @@ local function getHealth(redis_status)
    if redis_status["aof_enabled"] and redis_status["aof_enabled"] ~= 0 then
       -- If here the use of Redis Append Only File (AOF) is enabled
       -- so we should check for its errors
-      if redis_stats["aof_last_bgrewrite_status"] ~= "ok" or redis_status["aof_last_write_status"] ~= "ok" then
+      if redis_status["aof_last_bgrewrite_status"] ~= "ok" or redis_status["aof_last_write_status"] ~= "ok" then
 	 health = "red"
       end
    end


### PR DESCRIPTION
This error occur while using redis, due to this typo:
[AlertCheckLuaEngine.cpp:167] WARNING: Script failure[/usr/share/ntopng/scripts/callbacks/system/system.lua] [...topng/plugins0/callbacks/system/system/redis_monitor.lua:100: attempt to index a nil value (global 'redis_stats')]

This fix solves the problem.