### PR TITLE
htons(3) expect an unsigned integer as input, so lua_tointeger() look…

### DIFF
--- a/src/ParsedFlow.cpp
+++ b/src/ParsedFlow.cpp
@@ -127,17 +127,17 @@ void ParsedFlow::fromLua(lua_State *L, int index) {
 	if(!strcmp(key, "vlan_id"))
 	  vlan_id = lua_tonumber(L, -1);
 	else if(!strcmp(key, "version"))
-	  version = htons(lua_tonumber(L, -1));
+	  version = htons(lua_tointeger(L, -1));
 	else if(!strcmp(key, "src_port"))
-	  src_port = htons(lua_tonumber(L, -1));
+	  src_port = htons(lua_tointeger(L, -1));
 	else if(!strcmp(key, "dst_port"))
-	  dst_port = htons(lua_tonumber(L, -1));
+	  dst_port = htons(lua_tointeger(L, -1));
 	else if(!strcmp(key, "l4_proto"))
 	  l4_proto = lua_tonumber(L, -1);
 	else if(!strcmp(key, "tcp_flags"))
-	  tcp.tcp_flags = htons(lua_tonumber(L, -1));
+	  tcp.tcp_flags = htons(lua_tointeger(L, -1));
 	else if(!strcmp(key, "direction"))
-	  direction = htons(lua_tonumber(L, -1));
+	  direction = htons(lua_tointeger(L, -1));
 	else if(!strcmp(key, "first_switched"))
 	  first_switched = lua_tonumber(L, -1);
 	else if(!strcmp(key, "last_switched"))


### PR DESCRIPTION
…s more appropriate there.

Not sure why on FreeBSD armv7 it's causing an error, my best guess is that certain compiler/arch combinations refuse tu implicitly cast float to unsigned int.

Problem and patch reported and proposed by @rbgarga

This should fix #3743