### PR TITLE
Fix OpenSSL detection on FreeBSD.

### DIFF
--- a/configure.seed
+++ b/configure.seed
@@ -201,6 +201,11 @@ else
     AC_DEFINE_UNQUOTED(NO_SSL_DL, 1, [has openssl])
     SSL_INC="-I/usr/local/opt/openssl/include"
     SSL_LIB="-L/usr/local/opt/openssl/lib -lssl"
+  dnl Workaround for FreeBSD
+  elif test -f "/usr/lib/libssl.so"; then
+    AC_DEFINE_UNQUOTED(NO_SSL_DL, 1, [has openssl])
+    SSL_INC="-I/usr/include"
+    SSL_LIB="-L/usr/lib -lssl"
   else
     echo "Please install openssl-dev(el) package prerequisite"
     exit -1


### PR DESCRIPTION
FreeBSD provides a system OpenSSL library in /usr/lib, but that one cannot be detected by pkg-config. Add a condition to detect that one.

If a FreeBSD system has another ssl library installed which provides a pkg-config file(for example via ports collection) for detection that will be used.