### PR TITLE
Merge Simplified houskeeping loop to 4.0 (Fixes high CPU usage)

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -58,6 +58,7 @@ public:
   static u_int32_t hashString(const char * const s);
   static float timeval2ms(struct timeval *tv);
   static float msTimevalDiff(const struct timeval *end, const struct timeval *begin);
+  static u_int32_t usecTimevalDiff(const struct timeval *end, const struct timeval *begin);
   static size_t file_write(const char *path, const char *content, size_t content_len);
   static size_t file_read(const char *path, char **content);
   static bool file_exists(const char * const path);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -436,6 +436,25 @@ u_int32_t Utils::timeval2usec(const struct timeval *tv) {
 
 /* ****************************************************** */
 
+u_int32_t Utils::usecTimevalDiff(const struct timeval *end, const struct timeval *begin) {
+  if((end->tv_sec == 0) && (end->tv_usec == 0))
+    return(0);
+  else {
+    struct timeval res;
+    
+    res.tv_sec = end->tv_sec - begin->tv_sec;
+    if(begin->tv_usec > end->tv_usec) {
+      res.tv_usec = end->tv_usec + 1000000 - begin->tv_usec;
+      res.tv_sec--;
+    } else
+      res.tv_usec = end->tv_usec - begin->tv_usec;
+
+    return((res.tv_sec*1000000) + (res.tv_usec));
+  }
+}
+
+/* ****************************************************** */
+
 float Utils::msTimevalDiff(const struct timeval *end, const struct timeval *begin) {
   if((end->tv_sec == 0) && (end->tv_usec == 0))
     return(0);


### PR DESCRIPTION
Hi,

I was reported in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=246929 about ntopng 4./0 high CPU usage in FreeBSD. This was reported in comment to commit 607ba5226383.

After some digging I found out that merging commit 9fabefe to 4.0 does fix the issue.

So I'm sending this pull request to get it merged there.

Please note the commit to dev also included some code about "cping" variables, which looks like some functionality not present it 4.0, so I adapted the code by removing references to that.

I tested quickly this patch in FreeBSD and it seems to work fine.

I asked @mimugmail to also test it. Waiting for his report.

Thanks!