### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/README.CSRF.md
+++ b/doc/README.CSRF.md
@@ -1,6 +1,6 @@
 ## CSRF
 
-CSRF attacks rely on trusted, authenticated users which are tricked into performing a certain action on the web application. CSRF attacks craft a web url which is then visited by the victim. The victim's browser will send a session cookie when visiting the url, thus making the request completely legitimate from the perspective of the web application.
+CSRF attacks rely on trusted, authenticated users which are tricked into performing a certain action on the web application. CSRF attacks craft a web URL which is then visited by the victim. The victim's browser will send a session cookie when visiting the URL, thus making the request completely legitimate from the perspective of the web application.
 
 In general, CSRF protection is implemented using random tokens which are kept secret between the web application and the legitimate user.
 

--- a/doc/README.HTTP_AUTHENTICATOR
+++ b/doc/README.HTTP_AUTHENTICATOR
@@ -4,13 +4,13 @@ NTOP will request a POST to a URL with a JSON content:
 { "user": "username", "password": "password" }
 
 User is granted if webservice return code 200, anything else
-user is not granted. Content-type and answser content are not checked.
+user is not granted. Content-Type and answer content are not checked.
 
 If you want to grant a user as an administrator, webservice must
 reply a JSON like:
 { "admin": true }
 
-Some optionals fields can personalize user.
+Some optional fields can personalize user.
 You can set allowed ifname via optional allowedIfname field:
 { "allowedIfname": "ethX" }
 

--- a/doc/README.HTTP_AUTHENTICATOR
+++ b/doc/README.HTTP_AUTHENTICATOR
@@ -1,6 +1,6 @@
 HTTP authentication can be enabled from the ntopng preferences page.
 
-NTOP will request a POST to an url with a JSON content:
+NTOP will request a POST to a URL with a JSON content:
 { "user": "username", "password": "password" }
 
 User is granted if webservice return code 200, anything else
@@ -22,8 +22,8 @@ You can set language via optional language field:
 
 HTTP authentication parameters are discussed below.
 
-* HTTP Url
-Url to request for authentication.
+* HTTP URL
+URL to request for authentication.
 Examples:
     http://server.tld/auth
     https://server.tld/auth

--- a/doc/README.LDAP
+++ b/doc/README.LDAP
@@ -1,7 +1,7 @@
 # OpenLDAP as Active Directory proxy
 
 When using the sAMAccount account type in combination with OpenLDAP as an Active Directory proxy,
-the ntopng auth will not work because the "memberOf" attribute used by ntopng is not found.
+ntopng authentication will not work because the "memberOf" attribute used by ntopng is not found.
 In fact, OpenLDAP does not understand the "memberOf" attribute of AD and so it creates a
 MEMBEROF (uppercase) pseudo attribute, which is not standard.
 

--- a/doc/README.beta_features
+++ b/doc/README.beta_features
@@ -3,7 +3,7 @@ Instructions
 
 This file contains a list of beta/debugging features hidden into ntopng.
 These are subject to change. The feature can be enabled by enabling the
-corresponding redis preference. The correct sequence to follow is:
+corresponding Redis preference. The correct sequence to follow is:
 
   1. ntopng must be running
   2. run the feature-specific command

--- a/doc/README.compilation
+++ b/doc/README.compilation
@@ -75,7 +75,7 @@ On Windows you can download the Redis server from
 Note that:
 - you can use ZMQ 4.x in addition to 3.x (but not 2.x)
 - make sure nobody owns /var/lib/ntopng
-- make sure to have uglify-es to minify javascript code, just type, in the command line, `npm install -g uglify-es` to install it (`./autogen.sh && ./configure` is required after installing uglify-es, before running `make minify`)
+- make sure to have uglify-es to minify JavaScript code, just type, in the command line, `npm install -g uglify-es` to install it (`./autogen.sh && ./configure` is required after installing uglify-es, before running `make minify`)
 - make sure to have clean-css-cli to minify and optimize the CSS code, just type, in the command line, `npm install -g clean-css-cli`
 
 Source Code Compilation

--- a/doc/README.compilation
+++ b/doc/README.compilation
@@ -46,7 +46,7 @@ On Centos8
 - yum clean all
 - yum update
 - yum install openldap-devel libpcap-devel openssl-devel libcurl-devel libmaxminddb-devel sqlite-devel mysql-devel radcli-devel librdkafka-devel libcap-devel zeromq-devel rrdtool-devel json-c-devel expect geoipupdate
-- Then list the streams which provide redis (dnf module list redis) and install it. For example, to install it from stream 5 run: sudo dnf module install redis:5
+- Then list the streams which provide Redis (dnf module list redis) and install it. For example, to install it from stream 5 run: sudo dnf module install redis:5
 - yum install hiredis-devel
 
 On Fedora 30/31/32:
@@ -69,7 +69,7 @@ port install redis hiredis autoconf automake libtool rrdtool wget pkgconfig git 
 On FreeBSD
 See README.FreeBSD
 
-On Windows you can download the redis server from
+On Windows you can download the Redis server from
 - https://github.com/rgl/redis/downloads
 
 Note that:

--- a/doc/README.compilation
+++ b/doc/README.compilation
@@ -73,7 +73,7 @@ On Windows you can download the Redis server from
 - https://github.com/rgl/redis/downloads
 
 Note that:
-- you can use zmq 4.x in addition to 3.x (but not 2.x)
+- you can use ZMQ 4.x in addition to 3.x (but not 2.x)
 - make sure nobody owns /var/lib/ntopng
 - make sure to have uglify-es to minify javascript code, just type, in the command line, `npm install -g uglify-es` to install it (`./autogen.sh && ./configure` is required after installing uglify-es, before running `make minify`)
 - make sure to have clean-css-cli to minify and optimize the CSS code, just type, in the command line, `npm install -g clean-css-cli`

--- a/doc/README.eBPF.md
+++ b/doc/README.eBPF.md
@@ -31,7 +31,7 @@ Event producers have, in turn, to be instructed to deliver events to ntopng righ
 ./nprobe_mini   -v --zmq tcp://127.0.0.1:1234c
 ```
 
-One might need to adjust the ZMQ url to connect to an ntopng running on a remote machine or on a different port.
+One might need to adjust the ZMQ URL to connect to an ntopng running on a remote machine or on a different port.
 
 ### Setting up `libebpfflow`
 

--- a/doc/README.fritzbox
+++ b/doc/README.fritzbox
@@ -21,7 +21,7 @@ Example usage:
 ntopng/tools/fritzdump.sh <username> <password>
 ```
 
-*NOTE:* If you use password-only authentification pass "dslf-config" as username
+*NOTE:* If you use password-only authentication pass "dslf-config" as username
 
 As you can see in the script, it will connect to the Fritz!Box via http://fritz.box,
 authenticate with the user and password you passed and capture the traffic on the

--- a/doc/README.inline_http_configuration
+++ b/doc/README.inline_http_configuration
@@ -1,6 +1,6 @@
 nEdge can be configured via HTTP. During the startup process,
 it will try to retrieve users configuration from
-a url that has to be specified in file:
+a URL that has to be specified in file:
 
 /lua/modules/http_bridge_conf_utils.lua
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,10 +4,10 @@ See [README.compilation](README.compilation) for more information.
 
 Prior to Starting ntopng
 ---------------------
-Please make sure that you have redis server installed and active on the same host
-where ntopng will be running. If you plan to use a remote redis, please consider
-using the `--redis` option to specify a remote redis server IP address and port
-or a local socket. We suggest you run redis as a service so that you do not have
+Please make sure that you have a Redis server installed and active on the same host
+where ntopng will be running. If you plan to use a remote Redis server, please consider
+using the `--redis` option to specify a remote Redis server IP address and port
+or a local socket. We suggest you run Redis as a service so that you do not have
 to start it every time you want to use ntopng.
 
 
@@ -55,7 +55,7 @@ Note that you can optionally also specify the interface name.
 
 Using ntopng from Windows
 -------------------------
-1. Remember to start the redis server prior to start ntopng
+1. Remember to start the Redis server prior to start ntopng
 2. You must start ntopng as a service using the "Services" control panel
 
 

--- a/doc/README.nedge_http_configuration
+++ b/doc/README.nedge_http_configuration
@@ -1,6 +1,6 @@
 nEdge can be configured via HTTP. During the startup process,
 it will try to retrieve users configuration from
-a url that has to be specified in file:
+a URL that has to be specified in file:
 
 /lua/modules/http_bridge_conf_utils.lua
 

--- a/doc/README.redis
+++ b/doc/README.redis
@@ -1,6 +1,6 @@
-In order to avoid redis fillup all the available memory please set some memory limit in /etc/redis.conf
+In order to avoid Redis filling up all available memory please set some memory limit in /etc/redis.conf
 
-It is a good idea to setup some upper limits such as:
+It is a good idea to set some upper limits such as:
 
 maxmemory 300mb
 maxmemory-policy volatile-lru

--- a/doc/README.security.md
+++ b/doc/README.security.md
@@ -85,7 +85,7 @@ ntopng uses Redis as a cache for DNS names and other values. The Redis
 server by default listens only on the loopback address `127.0.0.1` but
 it is accessible without passwords.
 
-To secure the Redis server with a password, uncommend the
+To secure the Redis server with a password, uncomment the
 `requirepass` line of the Redis configuration file and specify a
 secure (very long) password here.
 

--- a/doc/nedge/src/introduction.rst
+++ b/doc/nedge/src/introduction.rst
@@ -117,7 +117,7 @@ As an example, let's suppose there are 3 different customers plans to manage:
 - Normal User: uses WiFi gateway by default, but may also use the 3G is WiFi is not available.
 - Gold User: can use any of the available gateways and it has a 70% of the available bandwidth reserved
 
-The desired behaviour is that a user should always use the less expensive gateway available,
+The desired behavior is that a user should always use the less expensive gateway available,
 based on its plan. If such a gateway becomes unavailable, Normal/Gold users should use an
 alternative gateway as long as it remains unavailable and then switch back to the less
 expensive when available.

--- a/doc/nedge/src/routing.rst
+++ b/doc/nedge/src/routing.rst
@@ -56,7 +56,7 @@ if DHCP client mode is enabled for the interface.
 
 Custom gateways can also be created at will. A typical example is the
 use of a single WAN port to route the traffic through different gateways. All the
-gateways and the nEdge WAN port itself are connected through a multiport swtich.
+gateways and the nEdge WAN port itself are connected through a multiport switch.
 In this case, all the gateways must be on the same IP network in order for nEdge
 to correctly route the traffic through them.
 

--- a/doc/src/advanced_features/additional_features.rst
+++ b/doc/src/advanced_features/additional_features.rst
@@ -8,4 +8,4 @@ always under active development and include:
 - Embedded-Systems aware including Raspberry Pi and Ubiquity Networks
 
 Please stay tuned and follow the ntop blog (http://blog.ntop.org) for all the latest news or visit the ntop
-Github page at http://github.com/ntop.
+GitHub page at http://github.com/ntop.

--- a/doc/src/advanced_features/live_pcap_download.rst
+++ b/doc/src/advanced_features/live_pcap_download.rst
@@ -14,7 +14,7 @@ page. You can control the pcap duration and set an optional BPF filter for furth
   Link for downloading the pcap file
 
 The pcap file can also be downloaded directly through http, using a command line tool such as `wget` or `curl`.
-The direct url for downloading the pcap is :code:`http://<ntopng IP>:3000/lua/live_traffic.lua?ifid=<interface index>&host=<host IP>`.
+The direct URL for downloading the pcap is :code:`http://<ntopng IP>:3000/lua/live_traffic.lua?ifid=<interface index>&host=<host IP>`.
 
 Please note that you should use cookies for authentication, as explained in the documentation. For example with `curl` you can specify
 username and password with :code:`--cookie "user=<user>; password=<password>"`

--- a/doc/src/api/lua_c/ntop/ntop_prefs.lua
+++ b/doc/src/api/lua_c/ntop/ntop_prefs.lua
@@ -18,7 +18,7 @@ function ntop.getPrefs()
 --! @return true on success, false otherwise.
 function ntop.flushCache()
 
---! @brief Retrieve a specific item in a redis list.
+--! @brief Retrieve a specific item in a Redis list.
 --! @param key the list item identifier.
 --! @param index the list index.
 --! @return the item on success, nil otherwise.

--- a/doc/src/api/timeseries/adding_new_timeseries.rst
+++ b/doc/src/api/timeseries/adding_new_timeseries.rst
@@ -29,7 +29,7 @@ Traffic elements are handled in some standard ways:
       class to modify (and related :code:`::lua` method).
 
    3. Some traffic elements are implemented in Lua. Their state is stored in Redis
-      usually in json form. This includes, for example, the SNMP devices.
+      usually in JSON form. This includes, for example, the SNMP devices.
 
 In order to add a custom timeseries it's necessary to identify the correct case
 above. It's also important to note that not all the traffic elements can be exported.

--- a/doc/src/basic_concepts/alerts.rst
+++ b/doc/src/basic_concepts/alerts.rst
@@ -188,7 +188,7 @@ Ntopng can detect possibly anomalous flows, and report them as alerts. Such flow
 
 Here is a list of possible flows alert types:
 
-  - **Flow Misbehaviour** (event): Indicates a generic misbehaviour. The alert description contains more details, namely:
+  - **Flow Misbehavior** (event): Indicates a generic misbehavior. The alert description contains more details, namely:
 
     + Slow TCP Connection
     + Slow Application Header

--- a/doc/src/cli_options.rst
+++ b/doc/src/cli_options.rst
@@ -66,7 +66,7 @@ ntopng supports a large number of command line parameters. To see what they are,
                                        | A password can be specified after
                                        | the port when Redis auth is required.
                                        | By default password auth is disabled.
-                                       | On Unix <fmt> can also be the redis socket file path.
+                                       | On Unix <fmt> can also be the Redis socket file path.
                                        | Port is ignored for socket-based connections.
                                        | Examples:
                                        | -r @2

--- a/doc/src/cli_options.rst
+++ b/doc/src/cli_options.rst
@@ -182,13 +182,13 @@ Some of the most important parameters are briefly discussed here.
 
 :code:`[—interface|-i] <interface|pcap>`
 
-   At the end of the help information there a list of all available interfaces. The user can select one or more interfaces from the list so that ntopng will treat them as monitored interfaces. Any traffic flowing though monitored interfaces will be seen and processed by ntopng. The interface is passed using the interface number (e.g., :code:`-i 1`) on Windonws systems, whereas the name is used on Linux / Unix systems (e.g., :code:`-i eth0`). A monitoring session using multiple interfaces can be set up as follows:
+   At the end of the help information there a list of all available interfaces. The user can select one or more interfaces from the list so that ntopng will treat them as monitored interfaces. Any traffic flowing though monitored interfaces will be seen and processed by ntopng. The interface is passed using the interface number (e.g., :code:`-i 1`) on Windows systems, whereas the name is used on Linux / Unix systems (e.g., :code:`-i eth0`). A monitoring session using multiple interfaces can be set up as follows:
 
    .. code:: bash
 
       ntopng -i eth0 -i eth1
 
-   To specify a zmq interface (that allows to visualise remotely-collected flows by nProbe and cento) you should add an interface like :code:`ntopng -i tcp://<endpoint ip>/`
+   To specify a zmq interface (that allows to visualize remotely-collected flows by nProbe and cento) you should add an interface like :code:`ntopng -i tcp://<endpoint ip>/`
 
    An example of ntopng and nprobe communication is
 

--- a/doc/src/cli_options.rst
+++ b/doc/src/cli_options.rst
@@ -188,7 +188,7 @@ Some of the most important parameters are briefly discussed here.
 
       ntopng -i eth0 -i eth1
 
-   To specify a zmq interface (that allows to visualize remotely-collected flows by nProbe and cento) you should add an interface like :code:`ntopng -i tcp://<endpoint ip>/`
+   To specify a ZMQ interface (that allows to visualize remotely-collected flows by nProbe and cento) you should add an interface like :code:`ntopng -i tcp://<endpoint ip>/`
 
    An example of ntopng and nprobe communication is
 
@@ -268,7 +268,7 @@ Some of the most important parameters are briefly discussed here.
    As mentioned above, a configuration file can be used in order to start ntopng. All the command line options can be reported in the configuration file, one per line. Options must be separated from their values using a :code:`=` sign. Comment lines starting with a :code:`#` sign are allowed as well.
 
 .. warning::
-   Unlike its predecessor, ntopng is not itself a Netflow collector. It can act as Netflow collector combined with nProbe. To perform this connection start nProbe with the :code:`--zmq` parameter and point ntopng interface parameter to the nProbe zmq endpoint. Using this configuration give the admin the possibility to use ntopng as collector GUI to display data either from nProbe captured traffic and Netflow enabled devices as displayed in the following picture.
+   Unlike its predecessor, ntopng is not itself a Netflow collector. It can act as Netflow collector combined with nProbe. To perform this connection start nProbe with the :code:`--zmq` parameter and point ntopng interface parameter to the nProbe ZMQ endpoint. Using this configuration give the admin the possibility to use ntopng as collector GUI to display data either from nProbe captured traffic and Netflow enabled devices as displayed in the following picture.
 
 
    .. figure:: img/cli_options_ntopng_with_nprobe_architecture.png

--- a/doc/src/how_to_start/running_as_a_daemon.rst
+++ b/doc/src/how_to_start/running_as_a_daemon.rst
@@ -132,7 +132,7 @@ Each daemon must have its own configuration file under
 :code:`/etc/ntopng`.
 
 In order to run multiple daemons on the same machine, each daemon
-must be guaranteed to have its own redis database (option :code:`-r`), its
+must be guaranteed to have its own Redis database (option :code:`-r`), its
 own HTTP/HTTPS ports (options :code:`-w` and :code:`-W`), and its own
 data directory (option :code:`-d`). Those options must be specified in
 each daemon's configuration file.

--- a/doc/src/how_to_start/running_on_windows.rst
+++ b/doc/src/how_to_start/running_on_windows.rst
@@ -17,7 +17,7 @@ You can start ntopng from cmd.exe only for debug purposes or for manipulating th
 
 .. warning::
 
-   ntopng requires the :code:`redis` service to be up and running or it will not start. Make sure this service is running and auto-started on boot. Check its status from the Services application.
+   ntopng requires the :code:`Redis` service to be up and running or it will not start. Make sure this service is running and auto-started on boot. Check its status from the Services application.
    
 List Monitored Interfaces
 ----------------------------
@@ -51,7 +51,7 @@ Windows services are started and stopped using the Services application part of 
 
 Troubleshooting
 ---------------
-ntopng requires the redis service to be activated in order to start. You can check redis status from the Services application.
+ntopng requires the Redis service to be activated in order to start. You can check Redis status from the Services application.
 
 In some Windows PCs, in particular those with WiFi adapters, ntopng might not be able to detect these adapters. Shall this be the case, we suggest you to uninstall the Win10Pcap drivers that are installed with ntopng and move to the ncap Windows drivers that can be installed from `ncap Windows drivers
 <https://nmap.org/npcap/windows-10.html>`_.

--- a/doc/src/plugins/alert_endpoints.rst
+++ b/doc/src/plugins/alert_endpoints.rst
@@ -10,7 +10,7 @@ trigger a specialized action based on the triggered alert.
 How They Work
 -------------
 
-Each alert endpoint has a dedicated redis FIFO queue. When an alert is triggered, ntopng enqueues the
+Each alert endpoint has a dedicated Redis FIFO queue. When an alert is triggered, ntopng enqueues the
 alerts JSON representation to each one of the enabled endpoints queues. Periodically ntopng invokes the
 endpoint logic which is responsible for dequeuing alerts from the queue and process them.
 

--- a/doc/src/plugins/examples.rst
+++ b/doc/src/plugins/examples.rst
@@ -581,5 +581,5 @@ The above information can be interpreted as:
 - `AccessSW-1` is connected to `NetworkSpine-2` via the interface with index `2111493`
 - The total traffic registered from `AccessSW-1` to `NetworkSpine-2` is 25151496709 bytes
 
-The user script keeps track of the old arcs by storing them into the redis key `ntopng.cache.snmp_topology_arcs_monitor.<device_ip>`.
+The user script keeps track of the old arcs by storing them into the Redis key `ntopng.cache.snmp_topology_arcs_monitor.<device_ip>`.
 By comparing the old registered arcs with the new ones it can determine if an arc was removed or added.

--- a/doc/src/using_with_other_tools/n2disk.rst
+++ b/doc/src/using_with_other_tools/n2disk.rst
@@ -214,7 +214,7 @@ REST API
 
 The pcap file can also be downloaded directly through http, running a live extraction. 
 It is possible to use a command line tool such as `wget` or `curl` for this.
-The direct url for downloading the pcap is 
+The direct URL for downloading the pcap is 
 :code:`http://<ntopng IP>:3000/lua/rest/get/pcap/live_extraction.lua?ifid=<id>&epoch_begin=<epoch>&epoch_end=<epoch>[&bpf_filter=<filter>]`
 
 Where:

--- a/doc/src/using_with_other_tools/nprobe.rst
+++ b/doc/src/using_with_other_tools/nprobe.rst
@@ -83,7 +83,7 @@ There are two main ways to gather flows from multiple NetFlow/sFlow exporters an
 
 2. By running multiple nProbe instances, one for each exporter. This method is the most performant
    because each exported data will be handled by a separate thread into ntopng so it can leverage
-   the cpu cores of a multicore system.
+   the CPU cores of a multicore system.
 
 Here is an example on how to configure multiple nProbe instances (second approach):
 

--- a/doc/src/web_gui/dashboard.rst
+++ b/doc/src/web_gui/dashboard.rst
@@ -64,7 +64,7 @@ Any port number shown can be double-clicked to visit the 'Active Flows' page. Th
 
 Applications
 ^^^^^^^^^^^^
-Application View provides another pie chart that represents a view of the bandwidth usage divided per application protocol. Protocol identification is done through ntopn nDPI engine. Protocols that cannot be identified are marked as Unknown.
+Application View provides another pie chart that represents a view of the bandwidth usage divided per application protocol. Protocol identification is done through the ntopng nDPI engine. Protocols that cannot be identified are marked as Unknown.
 
 .. figure:: ../img/web_gui_dashboard_community_pie_chart_top_applications.png
   :align: center

--- a/doc/src/web_gui/flows.rst
+++ b/doc/src/web_gui/flows.rst
@@ -139,7 +139,7 @@ Info
 ----
 
 Extra information nDPI is able to extract from the detected flow is made available in this field. This field
-may include urls, traffic profiles (in the Professional Version), contents of DNS requests, and so on.
+may include URLs, traffic profiles (in the Professional Version), contents of DNS requests, and so on.
 
 .. [1] Actually, flows may also exist between a host and a multicast group, as well as a broadcast domain.
 .. [2] https://github.com/ntop/nDPI

--- a/doc/src/web_gui/interfaces.rst
+++ b/doc/src/web_gui/interfaces.rst
@@ -96,14 +96,14 @@ Statistics
 Statistics page provides historical traffic statistics for the selected interface. The user can choose to filter
 statistics on a protocol basis and display data in several formats (e.g., bytes, packets, flows, and so on). In
 the Professional Version of ntopng, traffic for interface views in shown as stacked per physical interface.
-Physical interface visualisation can be toggled by clicking on the coloured dot just left of interface name.
+Physical interface visualization can be toggled by clicking on the coloured dot just left of interface name.
 
 The time series span can be adjusted by selecting values from 5 minutes up to 1 year. Moreover, drill-
 down is possible by clicking on the time series itself. Every click zooms the chart in, centering the time
 series around the clicked point.
 
 In addition, time series shown can be chosen via the dropdown menu labelled ‘Time series’. For example,
-it is possible to visualise all or just one protocol, traffic, packets, active hosts and flows, and so on. Ntopng
+it is possible to visualize all or just one protocol, traffic, packets, active hosts and flows, and so on. Ntopng
 is VLAN aware, hence if several VLANs are detected, traffic is accounted also on a VLAN basis.
 
 .. figure:: ../img/web_gui_interfaces_timeseries_dropdown.png

--- a/doc/src/web_gui/interfaces.rst
+++ b/doc/src/web_gui/interfaces.rst
@@ -54,7 +54,7 @@ Applications
 Applications page provides three pie charts and a specific table with nDPI-detected protocols for the selected
 interface.
 
-In the two top pie charts ntopng shows the application distribution and its categorisation. The bottom pie
+In the two top pie charts ntopng shows the application distribution and its categorization. The bottom pie
 chart shows nDPI-detected applications for currently active flows. All labels are clickable and point to
 detailed statistics pages. Belo pie charts there is a list of protocols detected with the corresponding total
 traffic, both in absolute terms and as a percentage of the total traffic.
@@ -248,7 +248,7 @@ The imported host pools will replace the existing ones.
 
 An “Alias” can be associated to each pool member to ease the its identification. Typically, one would
 assign a mnemonic label as member alias (e.g., “John’s iPhone” or “Smart TV”). A “Device Type” can be
-associated to each member as well. Devices types are used to categorise members on the basis of the
+associated to each member as well. Devices types are used to categorize members on the basis of the
 device type (e.g., TV, Camera, Smartphone).
 
 The image below shows an “IoT Devices” Host Pool with two members, namely a smart tv and a router.

--- a/doc/src/web_gui/interfaces.rst
+++ b/doc/src/web_gui/interfaces.rst
@@ -282,7 +282,7 @@ can assign.
   :alt: Interface DHCP Range Configuration
 
 When a DHCP range is configured, ntopng will monitor the DHCP traffic on the interface
-and report anomalous behaviours. For example, it detects if IP addresses are assigned outside
+and report anomalous behavior. For example, it detects if IP addresses are assigned outside
 the configured range and generate an alert. This can happen, for example, if a new
 misconfigured network device is attached to the network.
 

--- a/doc/src/web_gui/interfaces.rst
+++ b/doc/src/web_gui/interfaces.rst
@@ -183,8 +183,8 @@ statistics.
 
 **Create Interface Timeseries**:
 This setting toggles the generation of timeseries for the selected
-interface. No timeseries will be generated when this setting in
-unticked, including timeseries associated with local hosts and networks.
+interface. No timeseries will be generated when this setting is
+unchecked, including timeseries associated with local hosts and networks.
 
 **Create One-Way Traffic Timeseries**:
 This setting toggles the generation of timeseries for one way traffic, which

--- a/doc/src/web_gui/interfaces.rst
+++ b/doc/src/web_gui/interfaces.rst
@@ -33,7 +33,7 @@ Home
 
 In the Home page it is possible to view general interface information, such as Id (a unique integer
 identifier ntopng assigns to each monitored interface), family (e.g., pcap), and the overall traffic counters in
-bytes. It is possible to customise the interface name just by writing a custom name into the Name textbook
+bytes. It is possible to customize the interface name just by writing a custom name into the Name textbook
 and clicking on “Save Name”. Interface monitoring can be temporarily paused from the ‘State’ toggle
 buttons.
 

--- a/doc/src/web_gui/report.rst
+++ b/doc/src/web_gui/report.rst
@@ -109,7 +109,7 @@ on the network. It also provides the previous period data as long as comparison
 columns to easily analyze the difference between the two periods.
 
 Via the date picker at the top of the chart it's possible to easily jump to another
-period. The right and left arrows provide a conveniente way to jump to the next and
+period. The right and left arrows provide a convenient way to jump to the next and
 previous period respectively. Via the "Today" button it's possible to jump to the
 current day view, which show the traffic entity during the different hours of the day.
 

--- a/doc/src/web_gui/settings.rst
+++ b/doc/src/web_gui/settings.rst
@@ -77,7 +77,7 @@ It is possible to choose between the following options:
 - Export all the hosts data
 - Export all the local hosts data
 - Export all the remote hosts data
-- Export a specific host data, by specifing its IP or MAC address and optionally a VLAN
+- Export a specific host data, by specifying its IP or MAC address and optionally a VLAN
 
 The JSON data can be downloaded and easily analyzed.
 

--- a/doc/src/what_is_ntopng.rst
+++ b/doc/src/what_is_ntopng.rst
@@ -46,7 +46,7 @@ The ntopng service can be started/stopped using the launchctl command:
 Installing on Windows
 ---------------------
 
-Only the development build binary is available for windows. The binary can
+Only the development build binary is available for Windows. The binary can
 be downloaded from the `Windows package repository
 <https://packages.ntop.org/Windows/>`_.
 
@@ -87,7 +87,7 @@ in the ntopng installer.
    installation, without any extra step to download or install npcap
    drivers.
 
-The windows package does NOT contain geolocation files, due to restrictions as
+The Windows package does NOT contain geolocation files, due to restrictions as
 reported later in this section. So you need to download the geolocation files
 and then copy them into C:\\Program Files\\ntopng\\httpdocs\\geoip\\ directory, and
 then restart ntopng.

--- a/doc/src/what_is_ntopng.rst
+++ b/doc/src/what_is_ntopng.rst
@@ -26,8 +26,8 @@ Installing on MacOS
 
 MacOS installation packages can be found at
 http://packages.ntop.org/ and are installed with a GUI.
-ntopng requires redis to be installed in order to start. During the ntopng installation,
-if redis is not present, redis is installed and activated, otherwise the one already installed on
+ntopng requires Redis to be installed in order to start. During the ntopng installation,
+if Redis is not present, Redis is installed and activated, otherwise the one already installed on
 the system is used. After the installation, ntopng is started and active on local port 3000
 (i.e. ntopng is available at http://127.0.0.1:3000). If you want to uninstall ntopng you can
 open a terminal and type :code:`sudo /usr/local/bin/ntopng-uninstall.sh`


### PR DESCRIPTION
This is another batch of spelling corrections across the documentation files.