### PR TITLE
Added "key" parameter to GET function #4409

### DIFF
--- a/scripts/lua/rest/v1/get/l4/protocol/consts.lua
+++ b/scripts/lua/rest/v1/get/l4/protocol/consts.lua
@@ -32,6 +32,7 @@ for _, l4_key in pairs(l4_keys) do
    -- 2.3 number 1
    res[#res + 1] = {
      name = l4_key[1], 
+     other = l4_key[2],
      id = l4_key[3],
    }
 end


### PR DESCRIPTION
Like requested in the issue #4409, now the "GET /lua/rest/v1/get/l4/protocol/consts.lua" returns even the "key" parameter