### PR TITLE
Fixes #4373 get_category_protocols_list()

### DIFF
--- a/scripts/lua/rest/v1/get/l7/category/consts.lua
+++ b/scripts/lua/rest/v1/get/l7/category/consts.lua
@@ -18,13 +18,30 @@ local rest_utils = require "rest_utils"
 
 local rc = rest_utils.consts.success.ok
 local res = {}
+local app_list = {}
 
 local categories = interface.getnDPICategories()
+local applications = interface.getnDPIProtocols()
 
 for category, cat_id in pairs(categories) do
+
+   local tmp_app_list = {}
+
+   -- Get the list of the current cat_id
+
+   for tmp_proto_name, tmp_proto_id in pairsByKeys(interface.getnDPIProtocols(tonumber(cat_id)), asc_insensitive) do
+      tmp_app_list[#tmp_app_list + 1] = {
+         name = tmp_proto_name,
+         id   = tmp_proto_id,
+      }
+   end
+
+   -- Create the record for the cat_id
+
    res[#res + 1] = {
       name = category, 
       cat_id = tonumber(cat_id),
+      app_list = tmp_app_list,
    }
 end
 


### PR DESCRIPTION
Added to the json returned from "GET /lua/rest/v1/get/l7/application/consts.lua", the parameter "app_list" with the list of the applications for each protocol.