### PR TITLE
Fix nil check in influxdb.lua isCompatibleVersion()

### DIFF
--- a/scripts/lua/modules/timeseries/drivers/influxdb.lua
+++ b/scripts/lua/modules/timeseries/drivers/influxdb.lua
@@ -1655,7 +1655,7 @@ local function isCompatibleVersion(version)
   local current = toVersion(version)
   local required = toVersion(MIN_INFLUXDB_SUPPORTED_VERSION)
 
-  if (version == nil) or (required == nil) then
+  if (current == nil) or (required == nil) then
     return false
   end
 


### PR DESCRIPTION
While playing around with the timeseries feature I got the following exception when trying to use Telegraf's `inputs.influxdb_listener` as proxy to a Prometheus database.
```
...opng/scripts/lua/modules/timeseries/drivers/influxdb.lua:1643: attempt to index a nil value (local 'current')
```

`current` is likely supposed to be checked for nil earlier together with `required`, but instead of `current` the line is testing `version`, which isn't used anymore afterwards though.

This PR changes the check from `version == nil` to `current == nil`.

Since then I've discovered that proxying Prometheus via Telegraf's `influxdb_listener` doesn't work anyways since ntopng also tries to read from it, but that's a different story.