### PR TITLE
Add MAC and fingerprints to flows in syslog

### DIFF
--- a/include/ntop_flow.h
+++ b/include/ntop_flow.h
@@ -236,6 +236,8 @@
 #define TLS_CIPHER            NTOP_BASE_ID+493
 #define SSL_UNSAFE_CIPHER     NTOP_BASE_ID+494
 #define L7_PROTO_RISK         NTOP_BASE_ID+509
+#define HASSHC_HASH           NTOP_BASE_ID+525
+#define HASSHS_HASH           NTOP_BASE_ID+526
 
 /* SIP */
 #define SIP_CALL_ID NTOP_BASE_ID+130

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -2426,6 +2426,14 @@ json_object* Flow::flow2JSON() {
     if(srv_host && srv_host->getMac() && !srv_host->getMac()->isNull())
       json_object_object_add(my_object, Utils::jsonLabel(OUT_DST_MAC, "OUT_DST_MAC", jsonbuf, sizeof(jsonbuf)),
 			     json_object_new_string(Utils::formatMac(srv_host ? srv_host->get_mac() : NULL, buf, sizeof(buf))));
+  
+    if(isTLS() && protos.tls.ja3.client_hash)
+      json_object_object_add(my_object, Utils::jsonLabel(JA3C_HASH, "JA3C_HASH", jsonbuf, sizeof(jsonbuf)),
+           json_object_new_string(protos.tls.ja3.client_hash));
+
+    if(isSSH() && protos.ssh.hassh.client_hash)
+      json_object_object_add(my_object, Utils::jsonLabel(HASSHC_HASH, "HASSHC_HASH", jsonbuf, sizeof(jsonbuf)),
+           json_object_new_string(protos.ssh.hassh.client_hash));
   }
 
   if(cli_ip) {

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -2418,6 +2418,16 @@ json_object* Flow::flow2JSON() {
 			     json_object_new_string(Utils::formatMac(srv_host ? srv_host->get_mac() : NULL, buf, sizeof(buf))));
   }
 
+  if(ntop->getPrefs()->do_dump_flows_on_syslog()) {
+    if(cli_host && cli_host->getMac() && !cli_host->getMac()->isNull())
+      json_object_object_add(my_object, Utils::jsonLabel(IN_SRC_MAC, "IN_SRC_MAC", jsonbuf, sizeof(jsonbuf)),
+			     json_object_new_string(Utils::formatMac(cli_host ? cli_host->get_mac() : NULL, buf, sizeof(buf))));
+
+    if(srv_host && srv_host->getMac() && !srv_host->getMac()->isNull())
+      json_object_object_add(my_object, Utils::jsonLabel(OUT_DST_MAC, "OUT_DST_MAC", jsonbuf, sizeof(jsonbuf)),
+			     json_object_new_string(Utils::formatMac(srv_host ? srv_host->get_mac() : NULL, buf, sizeof(buf))));
+  }
+
   if(cli_ip) {
     if(cli_ip->isIPv4()) {
       json_object_object_add(my_object, Utils::jsonLabel(IPV4_SRC_ADDR, "IPV4_SRC_ADDR", jsonbuf, sizeof(jsonbuf)),


### PR DESCRIPTION
Added some fields to dump flows to syslog.

* Source MAC address
* Destination MAC address
* JA3 client fingerprint in TLS flow
* HASSH client fingerprint in SSH flow

Currently, MAC addresses are exported only to Elasticsearch.
From this comment (https://github.com/ntop/ntopng/issues/433#issuecomment-196435289), this restriction is in purpose of preventing possible space-related issues in MySQL dump.
I think it is not a problem in syslog dump.

-----

Question:

* Is it preferable to include fingerprints in ES dump?
* Is it preferable to include server fingerprints? (I thought client fingerprints are more important to be checked and traced.)