### PR TITLE
Fix some HTTP methods in API document

### DIFF
--- a/doc/src/api/rest/rest-api-v2.json
+++ b/doc/src/api/rest/rest-api-v2.json
@@ -1900,7 +1900,7 @@
 			}
 		},
 		"/lua/rest/v2/add/host/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -1933,7 +1933,7 @@
 			}
 		},
 		"/lua/rest/v2/add/network/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -1966,7 +1966,7 @@
 			}
 		},
 		"/lua/pro/rest/v2/add/snmp/device/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -1999,7 +1999,7 @@
 			}
 		},
 		"/lua/rest/v2/add/active_monitoring/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2032,7 +2032,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/interface/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2066,7 +2066,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/host/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2100,7 +2100,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/network/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2134,7 +2134,7 @@
 			}
 		},
 		"/lua/pro/rest/v2/edit/snmp/device/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2168,7 +2168,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/active_monitoring/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2202,7 +2202,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/flow/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2237,7 +2237,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/mac/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2272,7 +2272,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/host_pool/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2307,7 +2307,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/system/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2342,7 +2342,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/interface/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2373,7 +2373,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/host/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2404,7 +2404,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/network/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2435,7 +2435,7 @@
 			}
 		},
 		"/lua/pro/rest/v2/delete/snmp/device/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2466,7 +2466,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/active_monitoring/pool.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2497,7 +2497,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/pools.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Pools"
 				],
@@ -2517,7 +2517,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/recipients.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Notification Recipients"
 				],
@@ -2537,7 +2537,7 @@
 			}
 		},
 		"/lua/rest/v2/delete/endpoints.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Notification Endpoints"
 				],
@@ -2931,7 +2931,7 @@
 			}
 		},
 		"lua/rest/v2/export/all/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					"All"
 				],
@@ -2961,7 +2961,7 @@
 			}
 		},
 		"lua/rest/v2/export/active_monitoring/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					"Active Monitoring"
 				],
@@ -2990,7 +2990,7 @@
 			}
 		},
 		"lua/rest/v2/export/notifications/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					"Notifications"
 				],
@@ -3019,7 +3019,7 @@
 			}
 		},
 		"lua/rest/v2/export/pool/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					"Pools"
 				],
@@ -3048,7 +3048,7 @@
 			}
 		},
 		"lua/rest/v2/export/scripts/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					""
 				],
@@ -3077,7 +3077,7 @@
 			}
 		},
 		"lua/rest/v2/export/snmp/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					""
 				],
@@ -3370,7 +3370,7 @@
 			}
 		},
 	    "lua/rest/v2/get/ntopng/users.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					"Users"
 				],
@@ -3915,7 +3915,7 @@
 			}
 		},
 		"lua/rest/v2/export/infrastructure/config.lua": {
-			"post": {
+			"get": {
 				"tags": [
 					"Infrastructures"
 				],
@@ -3944,7 +3944,7 @@
 			}
 		},
 		"/lua/rest/v2/enable/check.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Checks"
 				],
@@ -3956,14 +3956,14 @@
 				],
 				"parameters": [{
 						"name": "check_subdir",
-						"in": "query",
+						"in": "form",
 						"description": "The check subdir",
 						"required": true,
 						"type": "string"
 					       },
 					       {
 						"name": "script_key",
-						"in": "query",
+						"in": "form",
 						"description": "The key of the script",
 						"required": true,
 						"type": "string"
@@ -3983,7 +3983,7 @@
 			}
 		},
 		"/lua/rest/v2/disable/check.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Checks"
 				],
@@ -3995,14 +3995,14 @@
 				],
 				"parameters": [{
 						"name": "check_subdir",
-						"in": "query",
+						"in": "form",
 						"description": "The check subdir",
 						"required": true,
 						"type": "string"
 					       },
 					       {
 						"name": "script_key",
-						"in": "query",
+						"in": "form",
 						"description": "The key of the script",
 						"required": true,
 						"type": "string"
@@ -5769,7 +5769,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/ntopng/incr_hosts.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Configuration"
 				],
@@ -5795,7 +5795,7 @@
 			}
 		},
 		"/lua/rest/v2/edit/ntopng/incr_flows.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Configuration"
 				],
@@ -5821,7 +5821,7 @@
 			}
 		},
 		"/lua/rest/v2/set/checks/config.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Checks"
 				],
@@ -5833,7 +5833,7 @@
 				],
 				"parameters": [{
 						"name": "JSON",
-						"in": "query",
+						"in": "form",
 						"description": "Check configuration in JSON",
 						"required": true,
 						"type": "string"
@@ -5873,7 +5873,7 @@
 				               },
 					       {
 						"name": "JSON",
-						"in": "query",
+						"in": "form",
 						"description": "Pool configuration in JSON",
 						"required": true,
 						"type": "string"
@@ -5925,7 +5925,7 @@
 			}
 		},
 		"/lua/rest/v2/import/checks/config.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"Checks"
 				],
@@ -5937,7 +5937,7 @@
 				],
 				"parameters": [{
 						"name": "JSON",
-						"in": "query",
+						"in": "form",
 						"description": "The Checks configuration in JSON",
 						"required": true,
 						"type": "string"
@@ -5972,7 +5972,7 @@
 				],
 				"parameters": [{
 						"name": "pool",
-						"in": "query",
+						"in": "form",
 						"description": "Pool identifier",
 						"required": true,
 						"type": "integer",
@@ -5980,7 +5980,7 @@
 				               },
 					       {
 						"name": "host_pool_members",
-						"in": "query",
+						"in": "form",
 						"description": "A newline-separated list of host pool members",
 						"required": true,
 						"type": "string"
@@ -6000,7 +6000,7 @@
 			}
 		},
 		"/lua/rest/v2/create/ntopng/api_token.lua": {
-			"get": {
+			"post": {
 				"tags": [
 					"User"
 				],
@@ -6012,7 +6012,7 @@
 				],
 				"parameters": [{
 						"name": "username",
-						"in": "query",
+						"in": "form",
 						"description": "An existing ntopng username",
 						"required": true,
 						"type": "string"


### PR DESCRIPTION
I **really** appreciate API v2, especially scripts APIs. Wonderful!

Nevertheless, it seems some of HTTP methods and parameter types in [API v2 document](https://www.ntop.org/guides/ntopng/api/rest/api_v2.html) are not correct.

cf. ) [Swagger document about parameter types](https://swagger.io/docs/specification/2-0/describing-parameters/)