### PR TITLE
build: respect ${PKG_CONFIG} in Makefiles

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,5 @@
 @PRO_MAKEFILE_INC@
+PKG_CONFIG ?= pkg-config
 prefix = @prefix@
 datadir = @datadir@
 datarootdir = @datarootdir@
@@ -45,9 +46,9 @@ endif
 
 ######
 LIBRRDTOOL_HOME=${PWD}/third-party/rrdtool-1.4.8
-HAS_LIBRRDTOOL=$(shell pkg-config --atleast-version=1.4.8 librrd && echo 0)
+HAS_LIBRRDTOOL=$(shell $(PKG_CONFIG) --atleast-version=1.4.8 librrd && echo 0)
 ifeq ($(HAS_LIBRRDTOOL), 0)
-	LIBRRDTOOL_INC = $(shell pkg-config --cflags librrd)
+	LIBRRDTOOL_INC = $(shell $(PKG_CONFIG) --cflags librrd)
 	LIBRRDTOOL_LIB = @LIBRRD_LD_FLAGS@
 else
 	LIBRRDTOOL_INC=-I$(LIBRRDTOOL_HOME)/src/
@@ -74,12 +75,12 @@ SNMP_LIB=@SNMP_LIB@
 
 ######
 
-HAS_ZSTD=$(shell pkg-config --exists libzstd && echo 0)
+HAS_ZSTD=$(shell $(PKG_CONFIG) --exists libzstd && echo 0)
 ifeq ($(HAS_ZSTD), 0)
    ifeq ($(OS), $(filter $(OS), FreeBSD))
 	ZSTD_LIB = /usr/local/lib/libzstd.a
      else
-	ZSTD_LIB = $(shell pkg-config --libs libzstd)
+	ZSTD_LIB = $(shell $(PKG_CONFIG) --libs libzstd)
    endif
 endif
 

--- a/tools/json2tlv/Makefile.in
+++ b/tools/json2tlv/Makefile.in
@@ -1,7 +1,8 @@
-HAS_JSON=$(shell pkg-config --exists json-c; echo $$?)
+PKG_CONFIG?=pkg-config
+HAS_JSON=$(shell $(PKG_CONFIG) --exists json-c; echo $$?)
 ifeq ($(HAS_JSON), 0)
-	JSON_INC = $(shell pkg-config --cflags json-c)
-	JSON_LIB = $(shell pkg-config --libs json-c)
+	JSON_INC = $(shell $(PKG_CONFIG) --cflags json-c)
+	JSON_LIB = $(shell $(PKG_CONFIG) --libs json-c)
 else
 	JSON_HOME=${PWD}/../../third-party/json-c
 	JSON_INC=-I$(JSON_HOME)


### PR DESCRIPTION
Allow overriding choice of pkg-config binary (this is useful
for cross-compilation in particular) within the Makefiles.

Not yet touching configure, so some work to be done still. As with nDPI, if you're interested in more build system PRs, let me know please. Thanks!

Signed-off-by: Sam James <sam@gentoo.org>