### PR TITLE
build: respect environment options more

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,11 @@ datarootdir = @datarootdir@
 SHELL=/bin/sh
 OS := $(shell uname -s)
 PWD=@PWD@
-GPP=@CXX@ -std=c++0x
+
+CXX=@CXX@
+CXXFLAGS?= -O2
+CXXFLAGS+=-std=c++0x
+
 INSTALL_DIR=$(DESTDIR)$(prefix)
 MAN_DIR=$(DESTDIR)@MAN_DIR@
 
@@ -123,22 +127,22 @@ OBJECTS_NO_MAIN := $(filter-out src/main.o,$(OBJECTS))
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 %.o: %.cpp $(HEADERS) $(INC) Makefile
-	$(GPP) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 .PRECIOUS: $(TARGET) $(OBJECTS)
 
 $(TARGET): $(OBJECTS) $(LIB_TARGETS) Makefile
-	$(GPP) $(OBJECTS) -Wall $(LDFLAGS) $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJECTS) -Wall $(LIBS) -o $@
 
 test_fifo_queue: $(OBJECTS_NO_MAIN) $(LIB_TARGETS)
 	rm src/FifoStringsQueue.o
 	$(MAKE) CPPFLAGS="${CPPFLAGS} -DTEST_FIFO_QUEUE -DDEBUG_FIFO_QUEUE" src/FifoStringsQueue.o
-	$(GPP) $(OBJECTS_NO_MAIN) -Wall $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJECTS_NO_MAIN) -Wall $(LIBS) -o $@
 
 test_alert_engine: $(OBJECTS_NO_MAIN) $(LIB_TARGETS)
 	rm src/AlertCheckLuaEngine.o
 	$(MAKE) CPPFLAGS="${CPPFLAGS} -DTEST_CHECK_ENGINE" src/AlertCheckLuaEngine.o
-	$(GPP) $(OBJECTS_NO_MAIN) -Wall $(LIBS) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(OBJECTS_NO_MAIN) -Wall $(LIBS) -o $@
 
 $(LUA_LIB):
 	$(MAKE) -C $(LUA_HOME) $(LUA_PLATFORM)

--- a/Makefile.in
+++ b/Makefile.in
@@ -141,14 +141,14 @@ test_alert_engine: $(OBJECTS_NO_MAIN) $(LIB_TARGETS)
 	$(GPP) $(OBJECTS_NO_MAIN) -Wall $(LIBS) -o $@
 
 $(LUA_LIB):
-	cd $(LUA_HOME); @GMAKE@ $(LUA_PLATFORM)
+	$(MAKE) -C $(LUA_HOME) $(LUA_PLATFORM)
 
 $(ZEROMQ_LIB):
-	cd $(ZEROMQ_HOME); ./configure --without-documentation --without-libsodium; @GMAKE@
+	cd $(ZEROMQ_HOME); ./configure --without-documentation --without-libsodium; $(MAKE)
 
 # --disable-rrd_graph
 $(LIBRRDTOOL_LIB):
-	cd $(LIBRRDTOOL_HOME); ./configure --disable-libdbi --disable-libwrap --disable-rrdcgi --disable-libtool-lock --disable-nls --disable-rpath --disable-perl --disable-ruby --disable-lua --disable-tcl --disable-python --disable-dependency-tracking --disable-rrd_graph ; cd src; @GMAKE@ librrd_th.la
+	cd $(LIBRRDTOOL_HOME); ./configure --disable-libdbi --disable-libwrap --disable-rrdcgi --disable-libtool-lock --disable-nls --disable-rpath --disable-perl --disable-ruby --disable-lua --disable-tcl --disable-python --disable-dependency-tracking --disable-rrd_graph ; cd src; $(MAKE) librrd_th.la
 
 hooks/.enabled:
 	git config core.hooksPath hooks || true
@@ -157,7 +157,7 @@ hooks/.enabled:
 clean:
 	-rm -f src/*.o src/*~ src/flow_checks/*.o  src/flow_checks/*~ src/flow_alerts/*.o  src/flow_alerts/*~ src/host_checks/*.o  src/host_checks/*~ src/host_alerts/*.o  src/host_alerts/*~ include/*~ *~ #config.h
 	-rm -f $(TARGET)
-	if [ -d pro ]; then cd pro && make clean; fi
+	if [ -d pro ]; then cd pro && $(MAKE) clean; fi
 
 cert:
 	openssl req -new -x509 -sha256 -extensions v3_ca -nodes -days 365 -out cert.pem
@@ -229,8 +229,8 @@ Makefile: configure Makefile.in
 	./configure
 
 minify:
-	cd httpdocs/js; make UGLIFY_VERSION=@UGLIFYJS_MAJOR_VERSION@ minify
-	cd httpdocs/css; make minify
+	$(MAKE) -C httpdocs/js UGLIFY_VERSION=@UGLIFYJS_MAJOR_VERSION@ minify
+	$(MAKE) -C httpdocs/css minify
 
 # Disabled to avoid too many recompilations
 #configure: @GIT_INDEX@

--- a/autogen.sh
+++ b/autogen.sh
@@ -33,45 +33,6 @@ if test -z $PKG_CONFIG; then
     exit
 fi
 
-##########################################
-
-TODAY=`date +%y%m%d`
-MAJOR_RELEASE="5"
-MINOR_RELEASE="1"
-SHORT_VERSION="$MAJOR_RELEASE.$MINOR_RELEASE"
-VERSION="$SHORT_VERSION.$TODAY"
-
-if test -d ".git"; then
-GIT_TAG=`git rev-parse HEAD`
-GIT_DATE=`date +%Y%m%d`
-GIT_RELEASE="$GIT_TAG:$GIT_DATE"
-GIT_BRANCH=`git rev-parse --abbrev-ref HEAD | sed "s/heads\///g"`
-else
-GIT_RELEASE="$VERSION"
-GIT_DATE=`date`
-GIT_BRANCH=""
-fi
-
-if test -d "pro"; then
-PRO_GIT_RELEASE=`cd pro; git log --pretty=oneline | wc -l`
-PRO_GIT_RELEASE=${PRO_GIT_RELEASE//[[:blank:]]/}
-PRO_GIT_DATE=`cd pro; git log --pretty=medium -1 | grep "^Date:" | cut -d " " -f 4-`
-else
-PRO_GIT_RELEASE=""
-PRO_GIT_DATE=""
-fi
-
-cat configure.seed | sed \
-    -e "s/@VERSION@/$VERSION/g" \
-    -e "s/@SHORT_VERSION@/$SHORT_VERSION/g" \
-    -e "s/@GIT_TAG@/$GIT_TAG/g" \
-    -e "s/@GIT_DATE@/$GIT_DATE/g" \
-    -e "s/@GIT_RELEASE@/$GIT_RELEASE/g" \
-    -e "s/@GIT_BRANCH@/$GIT_BRANCH/g" \
-    -e "s/@PRO_GIT_RELEASE@/$PRO_GIT_RELEASE/g" \
-    -e "s/@PRO_GIT_DATE@/$PRO_GIT_DATE/g" \
-    > configure.ac
-
 rm -f config.h config.h.in *~ #*
 
 echo "Wait please..."

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,4 @@
-odnl> Do not add anything above
-AC_INIT([ntopng],[@VERSION@])
-dnl> Do not add anything above
+AC_INIT([ntopng],[5.1.0])
 
 HERE=`pwd`
 SYSTEM=`uname -s`
@@ -44,8 +42,11 @@ AS_IF([test "${with_sanitizer+set}" = set],[
 dnl> Add /usr/local/ /opt/local
 CFLAGS="${CFLAGS} -I${HERE} -I${HERE}/include"
 CPPFLAGS="${CPPFLAGS} -I${HERE} -I${HERE}/include"
-NTOPNG_VERSION="@VERSION@"
-NTOPNG_SHORT_VERSION="@SHORT_VERSION@"
+
+NTOPNG_MAJOR=`echo "${PACKAGE_VERSION}" | cut -d . -f 1`
+NTOPNG_MINOR=`echo "${PACKAGE_VERSION}" | cut -d . -f 2`
+NTOPNG_PATCH=`echo "${PACKAGE_VERSION}" | cut -d . -f 3`
+NTOPNG_SHORT_VERSION="$NTOPNG_MAJOR.$NTOPNG_MINOR.$NTOPNG_PATCH"
 
 MACHINE=`uname -m`
 SYSTEM=`uname -s`
@@ -802,7 +803,6 @@ AC_SUBST(CFLAGS)
 AC_SUBST(CXXFLAGS)
 AC_SUBST(CPPFLAGS)
 AC_SUBST(LDFLAGS)
-AC_SUBST(PACKAGE_VERSION)
 AC_SUBST(NTOPNG_VERSION)
 AC_SUBST(NTOPNG_SHORT_VERSION)
 AC_SUBST(GIT_RELEASE)

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,7 @@ PKG_CHECK_MODULES([NDPI], [libndpi >= 2.0], [
    NDPI_INC=`echo $NDPI_CFLAGS | sed -e "s/[ ]*$//"`
    # Use static libndpi library as building against the dynamic library fails
    NDPI_LIB="-Wl,-Bstatic $NDPI_LIBS -Wl,-Bdynamic"
+   #NDPI_LIB="$NDPI_LIBS"
    NDPI_LIB_DEP=
    ], [
       AC_MSG_CHECKING(for nDPI source)

--- a/configure.ac
+++ b/configure.ac
@@ -121,19 +121,19 @@ fi
 dnl> Remove spaces
 OS="${OS#"${OS%%[![:space:]]*}"}"
 
-AC_CHECK_LIB([gpg-error], [gpg_strerror], [LDFLAGS="${LDFLAGS} -lgpg-error"])
-AC_CHECK_LIB([atomic], [__atomic_exchange_8], [LDFLAGS="${LDFLAGS} -latomic"])
+AC_CHECK_LIB([gpg-error], [gpg_strerror], [LIBS="${LIBS} -lgpg-error"])
+AC_CHECK_LIB([atomic], [__atomic_exchange_8], [LIBS="${LIBS} -latomic"])
 
 AC_CHECK_LIB([zmq], [zmq_socket_monitor])
 if test "x$ac_cv_lib_zmq_zmq_socket_monitor" = xyes; then :
-  LDFLAGS="$LDFLAGS -lzmq"
+  LIBS="${LIBS} -lzmq"
   AC_DEFINE_UNQUOTED(HAVE_ZMQ, 1, [ZMQ is present])
 else
   echo "ZMQ not present or too old (< v. 3.x)"
   exit
 fi
 
-AC_CHECK_LIB([sodium], [sodium_init], LDFLAGS="$LDFLAGS -lsodium")
+AC_CHECK_LIB([sodium], [sodium_init], LIBS="${LIBS} -lsodium")
 
 NEDGE=0
 if test "${with_nedge+set}" = set; then
@@ -156,7 +156,7 @@ if test "${with_nedge+set}" = set; then
     exit 1
   fi
 
-  LDFLAGS="${LDFLAGS} -lnetfilter_queue -lnfnetlink -lnetfilter_conntrack"
+  LIBS="${LIBS} -lnetfilter_queue -lnfnetlink -lnetfilter_conntrack"
 fi
 
 #
@@ -171,7 +171,7 @@ if test -d "/usr/local/include"; then
 fi
 
 if test -d "/usr/local/lib"; then
-  LDFLAGS="${LDFLAGS} -L/usr/local/lib"
+  LIBS="${LIBS} -L/usr/local/lib"
 fi
 
 if test -d /opt/local/include; then :
@@ -180,7 +180,7 @@ if test -d /opt/local/include; then :
 fi
 
 if test -d /opt/local/lib; then :
-  LDFLAGS="${LDFLAGS} -L/opt/local/lib"
+  LIBS="${LIBS} -L/opt/local/lib"
 fi
 
 if [ test -f /usr/bin/lsb_release ]; then
@@ -333,7 +333,7 @@ else
   fi
 fi
 
-AC_CHECK_LIB([gcrypt], [gcry_cipher_checktag], [LDFLAGS="${LDFLAGS} -lgcrypt"])
+AC_CHECK_LIB([gcrypt], [gcry_cipher_checktag], [LIBS="${LIBS} -lgcrypt"])
 
 AC_MSG_CHECKING(for ntopng professional edition)
 
@@ -377,7 +377,7 @@ PRO_OBJECTS='$(patsubst pro/%.cpp, pro/%.o, $(wildcard pro/*.cpp)) $(patsubst pr
 if test "${with_nedge+set}" != set; then
   if test $SYSTEM = "FreeBSD" || test $SYSTEM = "Darwin" || test $MACHINE = "armv7l" || test $MACHINE = "aarch64"; then
     cd ../PF_RING/userland/; ./configure; cd ./nbpf; ${MAKE}; cd ${HERE}
-    LDFLAGS="${LDFLAGS} -L../PF_RING/userland/nbpf -lnbpf"
+    LIBS="${LIBS} -L../PF_RING/userland/nbpf -lnbpf"
   fi
 fi
 
@@ -488,7 +488,7 @@ if test "${with_nedge+set}" != set; then
   if test -f "${PF_RING_HOME}/userland/lib/libpfring.a"; then
      echo "${PF_RING_HOME}/userland/libpcap/libpcap.a"
      if test -f "${PF_RING_HOME}/userland/libpcap/libpcap.a"; then
-       LDFLAGS="${LDFLAGS} ${PF_RING_HOME}/userland/lib/libpfring.a -L${PF_RING_HOME}/userland/libpcap/ `${PF_RING_HOME}/userland/lib/pfring_config --libs`"
+       LIBS="${LIBS} ${PF_RING_HOME}/userland/lib/libpfring.a -L${PF_RING_HOME}/userland/libpcap/ `${PF_RING_HOME}/userland/lib/pfring_config --libs`"
        CPPFLAGS="${CPPFLAGS} -I${PF_RING_HOME}/kernel -I${PF_RING_HOME}/userland/lib -I${PF_RING_HOME}/userland/libpcap"
        echo "Using PF_RING installed in ${PF_RING_HOME}"
      else
@@ -499,13 +499,13 @@ if test "${with_nedge+set}" != set; then
      if test -d "/opt/pfring"; then
        if test -f "/opt/pfring/lib/libpfring.a"; then
          echo "/opt/pfring/lib/libpfring.a"
-         LDFLAGS="${LDFLAGS} /opt/pfring/lib/libpfring.a -L/opt/pfring/lib"
+         LIBS="${LIBS} /opt/pfring/lib/libpfring.a -L/opt/pfring/lib"
          CPPFLAGS="${CPPFLAGS} -I/opt/pfring/include"
          echo "Using PF_RING installed in /opt/pfring"
       else
        if test -f "/usr/local/lib/libpfring.a"; then
         if test -f "/usr/local/lib/libpcap.a"; then
-    	  LDFLAGS="${LDFLAGS} /usr/local/lib/libpfring.a"
+    	  LIBS="${LIBS} /usr/local/lib/libpfring.a"
           echo "Using PF_RING installed in /usr/local/lib"
 	  AC_CHECK_LIB([pcap], [pcap_open_live], pcap=true)
 	  if test x$pcap = x
@@ -521,8 +521,8 @@ if test "${with_nedge+set}" != set; then
       fi
     fi
   else
-  LDFLAGS="${LDFLAGS} -lpfring -lpcap"
-  echo "Compiling ntopng with PF_RING support [${LDFLAGS}]"
+  LIBS="${LIBS} -lpfring -lpcap"
+  echo "Compiling ntopng with PF_RING support [${LIBS}]"
  fi
  fi
 else
@@ -582,12 +582,12 @@ fi
 
 AC_CHECK_LIB([cap], [cap_get_proc], cap=true)
 if test x$cap != x; then
-  LDFLAGS="${LDFLAGS} -lcap"
+  LIBS"${LIBS} -lcap"
   AC_DEFINE([HAVE_LIBCAP],[1],[Support for privilege drop])
 fi
 
 if test "${with_nedge+set}" != set; then
-  AC_CHECK_LIB([ldap], [ldap_initialize], [LDFLAGS="${LDFLAGS} -lldap -llber"])
+  AC_CHECK_LIB([ldap], [ldap_initialize], [LIBS="${LIBS} -lldap -llber"])
   if test "x$ac_cv_lib_ldap_ldap_initialize" = xyes; then
     AC_DEFINE_UNQUOTED(HAVE_LDAP, 1, [LDAP support is present])
   fi
@@ -601,15 +601,15 @@ fi
 
 AC_CHECK_LIB([rrd_th], [rrd_update_r], [LIBRRD_LD_FLAGS=-lrrd_th], [LIBRRD_LD_FLAGS=`pkg-config --libs librrd`])
 
-AC_CHECK_LIB([nl], [nl_handle_alloc], [LDFLAGS="${LDFLAGS} -lnl"])
-AC_CHECK_LIB([rt], [clock_gettime],   [LDFLAGS="${LDFLAGS} -lrt"])
+AC_CHECK_LIB([nl], [nl_handle_alloc], [LIBS="${LIBS} -lnl"])
+AC_CHECK_LIB([rt], [clock_gettime],   [LIBS="${LIBS} -lrt"])
 
-AC_CHECK_LIB([z], [zlibVersion], [LDFLAGS="${LDFLAGS} -lz"; AC_DEFINE_UNQUOTED(HAVE_ZLIB, 1, [zlib is present])])
+AC_CHECK_LIB([z], [zlibVersion], [LIBS="${LIBS} -lz"; AC_DEFINE_UNQUOTED(HAVE_ZLIB, 1, [zlib is present])])
 
 dnl> ldl (used by edjdb)
-AC_CHECK_LIB([dl], [dlopen], [LDFLAGS="${LDFLAGS} -ldl"])
+AC_CHECK_LIB([dl], [dlopen], [LIBS="${LIBS} -ldl"])
 
-AC_CHECK_LIB([curl], [curl_easy_perform], [LDFLAGS="${LDFLAGS} -lcurl"])
+AC_CHECK_LIB([curl], [curl_easy_perform], [LIBS="${LIBS} -lcurl"])
 if test ${ac_cv_lib_curl_curl_easy_perform} = "no"; then
   echo "Please install libcurl(-dev) (http://curl.haxx.se/)"
   exit 1
@@ -883,8 +883,10 @@ fi
 echo "
 This is the ntopng configuration:
 
-C++ Flags         : ${CPPFLAGS}
-System Libs       : ${LDFLAGS}
+Preprocessor Flags: ${CPPFLAGS}
+C++ Flags         : ${CXXFLAGS}
+Linker Flags:     : ${LDFLAGS}
+System Libs       : ${LIBS}
 nDPI Lib:         : ${NDPI_LIB}
 JSON Lib:         : ${JSON_LIB}
 SSL Lib:          : ${SSL_LIB}
@@ -895,7 +897,7 @@ MySQL Lib         : ${MYSQL_LIB}
 PCAP Lib          : ${LIBPCAP}
 Install path      : ${INSTALL_DIR}
 
-You are now ready to compile typing $GMAKE
+You are now ready to compile typing 'make'
 "
 
 if test "$DOWNLOAD_GEOIP" = "1"; then

--- a/tools/json2tlv/Makefile.in
+++ b/tools/json2tlv/Makefile.in
@@ -13,10 +13,11 @@ NDPI_HOME = ../../../nDPI
 NDPI_LIB = $(NDPI_HOME)/src/lib/libndpi.a
 NDPI_INC = -I$(NDPI_HOME)/src/include -I$(NDPI_HOME)/src/lib/third_party/include
 
-FLAGS=-O3
+CXXFLAGS?=-O3 -march=native -Wall -Wextra
+CXXFLAGS+=-std=c++11
 
 json2tlv: json2tlv.cpp
-	$(CXX) -std=c++11 $(FLAGS) -o $@ json2tlv.cpp $(JSON_INC) $(NDPI_INC) -Iinclude -march=native $(JSON_LIB) $(NDPI_LIB) -lzmq -lm -Wall -Wextra
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ json2tlv.cpp $(JSON_INC) $(NDPI_INC) -Iinclude $(JSON_LIB) $(NDPI_LIB) -lzmq -lm
 
 clean:
 	rm -f json2tlv


### PR DESCRIPTION
Very similar to the PR I've created for nDPI: https://github.com/ntop/nDPI/pull/1392.

- Respect `CXX`, `LDFLAGS` (this is particularly helpful for downstreams)
- Use `$(MAKE)` consistently for (very slightly) better parallel builds/installs
- Start using `configure.ac` instead of `configure.seed` (similar to https://github.com/ntop/nDPI/commit/cf931fda6bfb3925555c7bd11d950a886676bcb3).

In addition to being able to easily use e.g. Clang for testing now, it should be easier to test with different `LDFLAGS` (e.g. different `-fuse-ld=` or `-Wl,--as-needed`).