### PR TITLE
build: misc tiny fixes

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -187,7 +187,7 @@ fi
 
 if [ test -f /usr/bin/lsb_release ]; then
   CODENAME=`/usr/bin/lsb_release -c|cut -f 2`
-  if [[ $CODENAME == "wheezy" ]]; then :
+  if test $CODENAME = "wheezy" ; then
     CPPFLAGS="${CPPFLAGS} -DOLD_NETFILTER_INTERFACE=1"
   fi
 fi

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -720,10 +720,7 @@ fi
 
 AC_DEFINE_UNQUOTED(_CRT_SECURE_NO_WARNINGS, 1, [Disable warning on windows])
 
-GMAKE=`which gmake`
-if test x$GMAKE = x; then
-  GMAKE="make"
-fi
+GMAKE='$(MAKE)'
 
 GIT=`which git`
 if test x$GIT = x; then

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -132,7 +132,7 @@ if test "x$ac_cv_lib_zmq_zmq_socket_monitor" = xyes; then :
   AC_DEFINE_UNQUOTED(HAVE_ZMQ, 1, [ZMQ is present])
 else
   echo "ZMQ not present or too old (< v. 3.x)"
-  exit
+  exit 1
 fi
 
 AC_CHECK_LIB([sodium], [sodium_init], LIBS="${LIBS} -lsodium")


### PR DESCRIPTION
- Fail configure if ZMQ can't be found (as already intended)
- Avoid Bashism in configure
- Use $(MAKE) not 'make'