### PR TITLE
- Removed an unused variable

### DIFF
--- a/src/LuaEngineInterface.cpp
+++ b/src/LuaEngineInterface.cpp
@@ -4286,9 +4286,7 @@ static int ntop_interface_is_syslog_interface(lua_State* vm) {
 
 static int ntop_clickhouse_exec_csv_query(lua_State* vm) {
   NetworkInterface *ntop_interface = getCurrentInterface(vm);
-  const char* sql;
   struct mg_connection *conn = getLuaVMUserdata(vm, conn);
-  bool use_json = false;
   
   ntop->getTrace()->traceEvent(TRACE_DEBUG, "%s() called", __FUNCTION__);
 
@@ -4298,12 +4296,15 @@ static int ntop_clickhouse_exec_csv_query(lua_State* vm) {
   if(ntop_lua_check(vm, __FUNCTION__, 1, LUA_TSTRING) != CONST_LUA_OK)
     return(ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_PARAM_ERROR));
 
-  sql = lua_tostring(vm, 1);
+#ifdef HAVE_CLICKHOUSE
+
+  bool use_json = false;
+  
+  const char *sql = lua_tostring(vm, 1);
 
   if(lua_type(vm, 2) == LUA_TBOOLEAN) /* optional */
     use_json = lua_toboolean(vm, 2) ? true : false;
 
-#ifdef HAVE_CLICKHOUSE
   ntop_interface->exec_csv_query(sql, use_json, conn);
 #endif
 

--- a/src/LuaEngineNtop.cpp
+++ b/src/LuaEngineNtop.cpp
@@ -420,8 +420,6 @@ int ntop_store_triggered_alert(lua_State* vm, OtherAlertableEntity *alertable, u
   ScriptPeriodicity periodicity;
   u_int32_t score;
   AlertType alert_type;
-  //Host *host;
-  bool triggered;
 
   if(!alertable || !c->iface) return(ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_PARAM_ERROR));
 
@@ -443,7 +441,7 @@ int ntop_store_triggered_alert(lua_State* vm, OtherAlertableEntity *alertable, u
   if(ntop_lua_check(vm, __FUNCTION__, idx, LUA_TSTRING) != CONST_LUA_OK) return(ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_ERROR));
   if((alert_json = (char*)lua_tostring(vm, idx++)) == NULL) return(ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_PARAM_ERROR));
 
-  triggered = alertable->triggerAlert(vm, std::string(key), periodicity, time(NULL),
+  alertable->triggerAlert(vm, std::string(key), periodicity, time(NULL),
 				      score, alert_type, alert_subtype, alert_json);
 
   /* This looks like old code, Host Checks are C++ only now */


### PR DESCRIPTION
 In this PR just removed an unsed  variable warning and moved the declaration of use_json. It's a really minor thing. 
In case you have clickhouse you don't notice the warning in all other cases yes.

- Moved use_json near where it's needed.
	modified:   src/LuaEngineInterface.cpp
	modified:   src/LuaEngineNtop.cpp