### PR TITLE
configure.ac.in: Allow dynamic linking against ndpi 3.0

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -234,10 +234,8 @@ if test -d /usr/local/include/ndpi ; then :
 fi
 
 PKG_CHECK_MODULES([NDPI], [libndpi >= 2.0], [
-   NDPI_INC=`echo $NDPI_CFLAGS | sed -e "s/[ ]*$//"`
-   # Use static libndpi library as building against the dynamic library fails
-   NDPI_LIB="-Wl,-Bstatic $NDPI_LIBS -Wl,-Bdynamic"
-   #NDPI_LIB="$NDPI_LIBS"
+   NDPI_INC="$NDPI_CFLAGS"
+   NDPI_LIB="$NDPI_LIBS"
    NDPI_LIB_DEP=
    ], [
       AC_MSG_CHECKING(for nDPI source)


### PR DESCRIPTION
Linking statically is problematic since NDPI_LIBS is '-lndpi -lm'
and when we use -Bstatic it also brings in -lm to use libm.a and on some
architectures ( x86 ) which this does not work and results in missing symbols

Fixes
ipe-sysroot/usr/lib/libm.a(e_logf.o): in function `logf_ifunc_selector':
/usr/src/debug/glibc/2.35-r0/git/math/../sysdeps/i386/i686/multiarch/ifunc-sse2.h:30: undefined reference to `_dl_x86_cpu_features'

Signed-off-by: Khem Raj <raj.khem@gmail.com>