### PR TITLE
Added secure cookie attributes to ALL cookies on 302 response

### DIFF
--- a/src/HTTPserver.cpp
+++ b/src/HTTPserver.cpp
@@ -672,11 +672,13 @@ static void redirect_to_login(struct mg_connection *conn,
 	      "HTTP/1.1 302 Found\r\n"
 	      "Server: ntopng %s (%s)\r\n"
 	      "Set-Cookie: session=%s; path=/; expires=Thu, 01-Jan-1970 00:00:01 GMT; max-age=0;%s\r\n"  // Session ID
-	      "Set-Cookie: user=; path=/; expires=Thu, 01-Jan-1970 00:00:01 GMT; max-age=0;\r\n"
-	      "Set-Cookie: password=; path=/; expires=Thu, 01-Jan-1970 00:00:01 GMT; max-age=0;\r\n"
+	      "Set-Cookie: user=; path=/; expires=Thu, 01-Jan-1970 00:00:01 GMT; max-age=0;%s\r\n"
+	      "Set-Cookie: password=; path=/; expires=Thu, 01-Jan-1970 00:00:01 GMT; max-age=0;%s\r\n"
 	      "Location: %s%s%s%s%s%s%s%s\r\n\r\n",
 	      PACKAGE_VERSION, PACKAGE_MACHINE,
 	      session_id,
+	      get_secure_cookie_attributes(request_info),
+	      get_secure_cookie_attributes(request_info),
 	      get_secure_cookie_attributes(request_info),
 	      ntop->getPrefs()->get_http_prefix(), Utils::getURL((char*)LOGIN_URL, buf, sizeof(buf)),
 	      (referer || reason) ? "?" : "",


### PR DESCRIPTION
Our vulnerability assessment tools kept identifying ntopng as having vulnerabilities, specifically that cookies were missing the "Secure" attribute and the "httpOnly" attribute.  When working to mitigate the issue we found that the 302 redirect response was not including these attributes on the user or password cookies, but was including them on the session cookie.

We used the same method to set the secure cookie attributes across all 3 cookies which should resolve the issue.

While the original vulnerability does not appear to be exploitable, this change will allow ntopng to more easily pass vulnerability scans.

I've attached 2 images, one that shows the output from the vulnerability scan, and another that shows the response headers.
![ntopVulnerabilityScan](https://user-images.githubusercontent.com/100296754/155356911-1192a167-d76a-4e41-aab4-4e9bb815695e.png)

<img width="415" alt="ntopResponseHeaders" src="https://user-images.githubusercontent.com/100296754/155356969-bfa6eef0-0cbe-4e8e-a957-4f5efc3de633.png">

