### PR TITLE
Interim fix for issue 6832 - redis pwd complexity

### DIFF
--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -1275,7 +1275,7 @@ int Prefs::setOption(int optkey, char *optarg) {
 	c = strtok_r(NULL, ":", &w);
 	if(c) redis_port = atoi(c);
 
-	c = strtok_r(NULL, ":", &w);
+	c = strtok_r(NULL, "\0", &w);
 	if(c) redis_password = strdup(c);
       } else if(strlen(buf) > 0) {
 	/* only the host */


### PR DESCRIPTION
With the current optional values (port,pwd) in the --redis specification of 

`[h[:port[:pwd]]][@db-id] `

at https://www.ntop.org/guides/ntopng/cli_options/cli_options.html, problems are introduced when a complex password contains colons(:) or @ signs.

This pull request tokenizes the value until the end of the string for the password. It was previously tokenizing to the next ":" and truncating the value. It now tokenizes to "\0".
All characters are read so the password can be as complex as need be.

I have built and tested all the example formats on the doc page successfully. 

For redis passwords containing @ or : the command line value needs to be "fully qualified". Host, port and db-id are not optional. I am not sure if the docs need to be updated to reflect this.

I put "interim" in the title because I am not sure of the future plan for catering for complex passwords when redis, elasticsearch, mysql and clickhouse command line parameters contain delimiters. Redis 6 also caters for [username] pwd combo, not just pwd so I suspect some work coming up for that too.
I suspect the reason the command line options are the way they are now is to minimize the command line option "sprawl" caused if a username and password is introduced separately for each of the systems ?

This pull request is just an idea to help with issue 6832 because it will sort the redis password complexity problem.

Thanks

Jeff