### PR TITLE
Fix title discrepancy on known proto on non std port alert.

### DIFF
--- a/scripts/lua/modules/check_definitions/flow/known_proto_on_non_std_port.lua
+++ b/scripts/lua/modules/check_definitions/flow/known_proto_on_non_std_port.lua
@@ -21,7 +21,7 @@ local script = {
 
 
    gui = {
-      i18n_title = "flow_risk.ndpi_known_protocol_on_non_standard_port",
+      i18n_title = "alerts_dashboard.known_proto_on_non_std_port",
       i18n_description = "flow_risk.ndpi_known_protocol_on_non_standard_port",
    }
 }


### PR DESCRIPTION
On "known proto on non std port" alert were used two different title.