### PR TITLE
Add RIPEstat link to Host Details page

### DIFF
--- a/scripts/locales/cn.lua
+++ b/scripts/locales/cn.lua
@@ -1337,6 +1337,7 @@ local lang = {
     ["traffic_sent_received"] = "发送/接收的流量",
     ["vlan_id"] = "VLAN ID",
     ["whois_lookup"] = "Whois 查询",
+    ["ripestat_lookup"] = "RIPEstat 查询",
   },
   ["developer_section"] = {
     ["datasources_list"] = "数据源",

--- a/scripts/locales/cz.lua
+++ b/scripts/locales/cz.lua
@@ -685,6 +685,7 @@ local lang = {
     ["traffic_sent_received"] = "Provoz odeslán / přijat",
     ["vlan_id"] = "VLAN ID",
     ["whois_lookup"] = "Whois Lookup",
+    ["ripestat_lookup"] = "RIPEstat Lookup",
   },
   ["device_protocols"] = {
     ["alert"] = "Spustit upozornění",

--- a/scripts/locales/de.lua
+++ b/scripts/locales/de.lua
@@ -464,6 +464,7 @@ local lang = {
     ["traffic_sent_received"] = "Gesendeter / erhaltener Datenverkehr",
     ["vlan_id"] = "VLAN ID",
     ["whois_lookup"] = "Whois Lookup",
+    ["ripestat_lookup"] = "RIPEstat Lookup",
   },
   ["device_types"] = {
     ["iot"] = "IoT",

--- a/scripts/locales/en.lua
+++ b/scripts/locales/en.lua
@@ -1960,6 +1960,7 @@ local lang = {
     ["unidirectional_tcp_flows"] = "Total Unidirectional TCP/UDP Flows",
     ["vlan_id"] = "VLAN ID",
     ["whois_lookup"] = "Whois Lookup",
+    ["ripestat_lookup"] = "RIPEstat Lookup",
   },
   ["developer_section"] = {
     ["datasources_list"] = "Datasources",

--- a/scripts/locales/it.lua
+++ b/scripts/locales/it.lua
@@ -1917,6 +1917,7 @@ local lang = {
     ["unidirectional_tcp_flows"] = "Totale dei Flussi TCP Unidirezionali",
     ["vlan_id"] = "VLAN ID",
     ["whois_lookup"] = "Ricerca Whois",
+    ["ripestat_lookup"] = "Ricerca RIPEstat",
   },
   ["developer_section"] = {
     ["datasources_list"] = "Sorgenti",

--- a/scripts/locales/jp.lua
+++ b/scripts/locales/jp.lua
@@ -1614,6 +1614,7 @@ local lang = {
     ["traffic_sent_received"] = "トラフィック 送信 / 受信",
     ["vlan_id"] = "VLAN ID",
     ["whois_lookup"] = "ルックアップは誰か",
+    ["ripestat_lookup"] = "RIPEstat でのルックアップ",
   },
   ["developer_section"] = {
     ["datasources_list"] = "データソース",

--- a/scripts/locales/pt.lua
+++ b/scripts/locales/pt.lua
@@ -555,6 +555,7 @@ local lang = {
     ["traffic_sent_received"] = "Tráfego enviado / recebido",
     ["vlan_id"] = "ID de VLAN",
     ["whois_lookup"] = "Whois Lookup",
+    ["ripestat_lookup"] = "RIPEstat Lookup",
   },
   ["device_protocols"] = {
     ["alert"] = "Alerta de gatilho",

--- a/scripts/lua/host_details.lua
+++ b/scripts/lua/host_details.lua
@@ -672,7 +672,7 @@ else
          print("<tr><th>"..i18n("asn").."</th><td>")
 
          print("<A HREF='" .. ntop.getHttpPrefix() .. "/lua/hosts_stats.lua?asn=".. host.asn .."'>"..host.asname.."</A> [ "..i18n("asn").." <A HREF='" .. ntop.getHttpPrefix() .. "/lua/hosts_stats.lua?asn=".. host.asn.."'>".. host.asn.."</A> ]</td>")
-         print('<td><A class="ntopng-external-link" href="http://itools.com/tool/arin-whois-domain-search?q='.. host["ip"] ..'&submit=Look+up">'..i18n("details.whois_lookup")..' <i class="fas fa-external-link-alt"></i></A></td>')
+         print('<td><A class="ntopng-external-link" href="http://itools.com/tool/arin-whois-domain-search?q='.. host["ip"] ..'&submit=Look+up">'..i18n("details.whois_lookup")..' <i class="fas fa-external-link-alt"></i></A> <A class="ntopng-external-link" href="https://stat.ripe.net/'.. host["ip"] ..'">'..i18n("details.ripestat_lookup")..' <i class="fas fa-external-link-alt"></i></A></td>')
          print("</td></tr>\n")
       end
 

--- a/scripts/lua/modules/lua_utils_print.lua
+++ b/scripts/lua/modules/lua_utils_print.lua
@@ -19,7 +19,7 @@ end
 function printASN(asn, asname)
   asname = asname:gsub('"','')
   if(asn > 0) then
-   return("<A class='ntopng-external-link' href='http://as.robtex.com/as"..asn..".html'>"..asname.." <i class='fas fa-external-link-alt fa-lg'></i></A>")
+   return("<A class='ntopng-external-link' href='https://stat.ripe.net/AS"..asn..".html'>"..asname.." <i class='fas fa-external-link-alt fa-lg'></i></A>")
   else
     return(asname)
   end


### PR DESCRIPTION
As mentioned in #7346 I would like to add a RIPEstat lookup link to the host details page.
I created a translation for every language, by looking what was already there for Whois and looking it up on a translator, so it might not be completely correct (beside my main languages English and German).

Beside that I noticed that the robtex link looks to be broken and already using RIPEstat on the details page, so this also changes the list link.

I tested this change on a running system, so it shouldn't break something.