### PR TITLE
Add code formatter in the CI pipeline

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,7 @@
+---
 BasedOnStyle: Google
-
+---
+Language: Cpp
+IndentWidth: 2
+SortIncludes: Never
+---

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
 on:
+  pull_request:
+    branches: [dev]
   workflow_run:
     workflows: [Formatter]
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build
 on:
-  push:
-    branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev" ]
+  workflow_run:
+    workflows: [Formatter]
+    types:
+     - completed
+    branches: [dev]
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,0 +1,23 @@
+# This workflow uses clang-format to force the right coding style.
+name: Formatter
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+jobs:
+  formatter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run formatter
+      - run: find ./src ./include/ -type f -name '*.cpp' -o -name '*.h' -exec clang-format --style=file -i '{}' \;
+      
+      - name: Commit
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: clang-format-bot
+          commit_message: 'Automated commit of clang-format CI changes.'

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   formatter:
     runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -4,8 +4,6 @@ name: Formatter
 on:
   push:
     branches: [ "dev" ]
-  pull_request:
-    branches: [ "dev" ]
   workflow_dispatch:
 jobs:
   formatter:
@@ -25,12 +23,6 @@ jobs:
       # Commit the changes when pushing to a remote branch
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4
-        if: ${{ github.event_name == 'push' }}
         with:
           commit_user_name: clang-format-bot
           commit_message: 'Automated commit of clang-format CI changes.'
-
-      # When in a pull request, just fail the job if it doesn't follow the coding style
-      - name: Check for changes
-        if: ${{ github.event_name == 'pull_request' }}
-        run: git diff --exit-code

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Run formatter
         run: find ./src ./include/ -type f \( -name '*.cpp' -o -name '*.h' \) -exec clang-format --style=file -i '{}' \;

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run formatter
-      - run: find ./src ./include/ -type f -name '*.cpp' -o -name '*.h' -exec clang-format --style=file -i '{}' \;
+        run: find ./src ./include/ -type f -name '*.cpp' -o -name '*.h' -exec clang-format --style=file -i '{}' \;
       
       - name: Commit
-      - uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_user_name: clang-format-bot
           commit_message: 'Automated commit of clang-format CI changes.'

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -6,6 +6,7 @@ on:
     branches: [ "dev" ]
   pull_request:
     branches: [ "dev" ]
+  workflow_dispatch:
 jobs:
   formatter:
     runs-on: ubuntu-latest

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run formatter
-        run: find ./src ./include/ -type f -name '*.cpp' -o -name '*.h' -exec clang-format --style=file -i '{}' \;
+        run: find ./src ./include/ -type f \( -name '*.cpp' -o -name '*.h' \) -exec clang-format --style=file -i '{}' \;
       
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -18,14 +18,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Run formatter
         run: find ./src ./include/ -type f \( -name '*.cpp' -o -name '*.h' \) -exec clang-format --style=file -i '{}' \;
       
+      # Commit the changes when pushing to a remote branch
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ github.event_name == 'push' }}
         with:
           commit_user_name: clang-format-bot
           commit_message: 'Automated commit of clang-format CI changes.'
+
+      # When in a pull request, just fail the job if it doesn't follow the coding style
+      - name: Check for changes
+        if: ${{ github.event_name == 'pull_request' }}
+        run: git diff --exit-code


### PR DESCRIPTION
This workflow will use clang-format to enforce a coding style (defined in `.clang-format`) to all the cpp source files.

The coding style is based on [Google style](https://google.github.io/styleguide/cppguide.html) with few differences:
 - Indentation is 2 spaces
 - Do not reorder the included headers because this potentially disrupt the dependencies between them

**Note:** This PR will affect ~600 files, in order to preserve the git blame it's possible to put the commit ID in which the code formatting takes place in the `.git-blame-ignore-revs` file, this will force git blame to ignore these changes (https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt)