### PR TITLE
Ignore the mass code reformatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Since version 2.23 (released in August 2019), git-blame has a feature
+# to ignore or bypass certain commits.
+#
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Automated commit of clang-format CI changes.
+d395deac4e0d3f6b4f79213290b775298c0c82d6


### PR DESCRIPTION
Create the file `.git-blame-ignore-revs` and append the commit d395deac4e0d3f6b4f79213290b775298c0c82d6 that is responsible for the mass code reformatting.