### PR TITLE
Fix compilation errors introduced by https://github.com/ntop/ntopng/pull/7430

### DIFF
--- a/fuzz/Makefile.in
+++ b/fuzz/Makefile.in
@@ -7,9 +7,8 @@ LIB_FUZZING_ENGINE := @LIB_FUZZING_ENGINE@
 FUZZ_OBJECTS := @FUZZ_OBJECTS@
 FUZZ_WITH_PROTOBUF := @FUZZ_WITH_PROTOBUF@
 
-OBJECTS := $(OBJECTS) $(FUZZ_OBJECTS)
-FUZZ_FILTER_OUT := $(FUZZ_OBJECTS:fuzz/stub/%Stub.o=src/%.o)
-OBJECTS_NO_MAIN := $(filter-out src/main.o $(FUZZ_FILTER_OUT),$(OBJECTS))
+STUB_FILTER_OUT := $(FUZZ_OBJECTS:fuzz/stub/%Stub.o=src/%.o)
+OBJECTS_FOR_FUZZ := $(filter-out src/main.o $(STUB_FILTER_OUT),$(OBJECTS))
 
 # Protobuf dependencies
 fuzz_dissect_packet_proto_sources := fuzz/proto/pcap.pb.o
@@ -36,10 +35,10 @@ fuzz/proto/%.pb.o: fuzz/%.proto
 fuzz/%.o: fuzz/%.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
-fuzz/fuzz_dissect_packet: fuzz/fuzz_dissect_packet.o $(fuzz_dissect_packet_proto_sources) $(OBJECTS_NO_MAIN)
+fuzz/fuzz_dissect_packet: fuzz/fuzz_dissect_packet.o $(fuzz_dissect_packet_proto_sources) $(FUZZ_OBJECTS) $(OBJECTS_FOR_FUZZ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(LIB_FUZZING_ENGINE) $^ $(LIBS) -o $@
 
-fuzz/%: fuzz/%.o $(OBJECTS_NO_MAIN)
+fuzz/%: fuzz/%.o $(FUZZ_OBJECTS) $(OBJECTS_FOR_FUZZ)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(LIB_FUZZING_ENGINE) $^ $(LIBS) -o $@
 
 fuzz_corpus: $(FUZZ_CORPUS)

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -3,7 +3,34 @@
 The targets are meant to be run by google oss-fuzz however you can test it locally by
 configuring all the required flags.
 
-## Flags
+## How to build
+
+In order to build all the targets you need to do the following:
+ - Enable the fuzzing targets either with `--enable-fuzztargets` or `--enable--fuzztargets-local`
+ - Pass to the C++ preprocessor the flag `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`
+ - Use the makefile target `fuzz_all`
+
+### Steps
+
+1. Run autoconf with
+
+```shell
+./autogen.sh
+```
+
+2. Run the configure scripts enabling the fuzzing targets (look at [Flags](#flags) for more details)
+
+```shell
+CPPFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" ./configure --enable-fuzztargets-local
+```
+
+3. Build the `fuzz_all` target
+
+```shell
+make -j$(nproc) fuzz_all
+```
+
+### Flags
 
 These are all the flags that can be passed to the C/C++ compiler:
  - [REQUIRED] **FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION**


### PR DESCRIPTION
This will fix the compilation errors that were introduced by https://github.com/ntop/ntopng/pull/7430

Remember that in order to build the actual fuzzing targets you need to enable them with `--enable-fuzztargets` or `--enable-fuzztargets-local` **and** pass the flag `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` to the C++ preprocessor.

The building target is `fuzz_all`

For example you can run
```shell
CPPFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION" ./configure --enable-fuzztargets-local

make -j$(nproc) fuzz_all
```

Please refer to [fuzz/README.md](https://github.com/patacca/ntopng/blob/fuzz/fuzz/README.md) for more information on the building process.