### PR TITLE
Copyright fix for Y2K

### DIFF
--- a/attic/tools/nindex_export_to_ch.sh
+++ b/attic/tools/nindex_export_to_ch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright (C) 1998-22 - ntop.org
+#  Copyright (C) 1998 - ntop.org
 #
 #  http://www.ntop.org/
 #

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -1,6 +1,6 @@
 /*
  *
- * (C) 2013-23 - ntop.org
+ * (C) 2013 - ntop.org
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -210,7 +210,7 @@
 #define MAX_NUM_QUEUED_ADDRS \
   500 /* Maximum number of queued address for resolution */
 #define MAX_NUM_QUEUED_CONTACTS 25000
-#define NTOP_COPYRIGHT "(C) 1998-23 ntop.org"
+#define NTOP_COPYRIGHT "(C) 1998 ntop.org"
 #define DEFAULT_PID_PATH "/var/run/ntopng.pid"
 #define SYSTEM_INTERFACE_NAME "__system__"
 #define SYSTEM_INTERFACE_ID -1

--- a/ntopng.8
+++ b/ntopng.8
@@ -1,4 +1,4 @@
-.\" This file Copyright 1998-16 ntop.org
+.\" This file Copyright 1998 ntop.org
 .\"
 .
 .de It

--- a/packages/wizard/ntopng-config.in
+++ b/packages/wizard/ntopng-config.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-#  Copyright (C) 2002-20 - ntop.org
+#  Copyright (C) 2002 - ntop.org
 #
 #  http://www.ntop.org/
 #
@@ -21,7 +21,7 @@ esac
 
 function showHelp {
     {
-	company="(C) 1998-21 ntop.org\n\n"
+	company="(C) 1998 ntop.org\n\n"
 	usage="Usage:\n\tntopng-conf\n\tor\n\tntopng-conf <command line options>\n\nOptions:\n"
 	X_option="[-X] <num>          | Set max number of active flows to <num>\n"
 	x_option="[-x] <num>          | Set max number of active hosts to <num>\n"

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * (C) 2013-23 - ntop.org
+ * (C) 2013 - ntop.org
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -524,7 +524,7 @@ void Ntop::start() {
   if (PACKAGE_OS[0] != '\0')
     getTrace()->traceEvent(TRACE_NORMAL, "Built on %s", PACKAGE_OS);
 
-  getTrace()->traceEvent(TRACE_NORMAL, "(C) 1998-23 ntop");
+  getTrace()->traceEvent(TRACE_NORMAL, "(C) 1998 ntop");
 
   last_modified_static_file_epoch = start_time = time(NULL);
   snprintf(epoch_buf, sizeof(epoch_buf), "%u", (u_int32_t)start_time);

--- a/src/service_win32.c
+++ b/src/service_win32.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 1998-2019 Luca Deri <deri@ntop.org>
+ *  Copyright (C) 1998 Luca Deri <deri@ntop.org>
  *
  *  			    http://www.ntop.org/
  *


### PR DESCRIPTION
This PR fixes some nonsense ranges mentioned in copyright strings, like:

```
(C) 1998-23 ntop.org
```

It's unclear how one is supposed to parse "1998-23" since the two most obvious are "1998 minus 23 (1975)" and "1998 - 1923" (when in fact it's certainly supposed to be parsed as "1998-2023," but computers are dumb and can't figure that out, thus the whole [Y2k problem](https://education.nationalgeographic.org/resource/Y2K-bug/)).

But, regardless of the weird YYYY-YY range, copyright statements generally should merely be the date of first published, per [this helpful site](https://www.copyrightlaws.com/copyright-symbol-notice-year/#:~:text=Which%20Year%20Should%20You%20Use,first%20publication%20of%20the%20work.). [Here's the real law](https://www.copyright.gov/title17/92chap4.html) on copyright in the US (note, no ranges). The Free Software Foundation recommends ranges, but the FSF is wrong and should be ignored generally anyway. That last part is like, just my opinion, man.

I also fixed a couple other ranges when they were nearby, but the main one I wanted to fix was the one emblazoned at the bottom of every ntop screen when I'm using it. I can comfortably ignore the other nonsense copyright ranges scattered around license text and source code, but that one I have to look at all the time, and it annoys me.

Finally, I'll be damned if I leave a Y2K bug unfixed this late in my career. I did all this almost a quarter century ago.
