### PR TITLE
Ignore leaks

### DIFF
--- a/fuzz/fuzz_dissect_packet.options
+++ b/fuzz/fuzz_dissect_packet.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+detect_leaks=0


### PR DESCRIPTION
Disabling leaks detection should be useful for increasing the coverage.
See also https://github.com/google/oss-fuzz/issues/10323