### PR TITLE
Remove the is_blacklisted boolean and the unused ntop_host_blacklist method.

### DIFF
--- a/include/Host.h
+++ b/include/Host.h
@@ -161,7 +161,7 @@ class Host : public GenericHashEntry,
   bool has_blocking_quota, has_blocking_shaper;
 #endif
   u_int16_t is_in_broadcast_domain : 1, is_dhcp_host : 1,
-      is_crawler_bot_scanner : 1, is_blacklisted : 1, is_rx_only : 1,
+      is_crawler_bot_scanner : 1, is_rx_only : 1,
       more_then_one_device : 1, stats_reset_requested : 1,
       name_reset_requested : 1, data_delete_requested : 1, prefs_loaded : 1,
       deferred_init : 1, _notused : 6;
@@ -397,8 +397,7 @@ class Host : public GenericHashEntry,
   inline bool isIPv4() const { return ip.isIPv4(); };
   inline bool isIPv6() const { return ip.isIPv6(); };
   void set_mac(Mac *m);
-  inline bool isBlacklisted() const { return (is_blacklisted); };
-  inline void blacklistHost() { is_blacklisted = true; };
+  inline bool isBlacklisted() const { return (((blacklist_name != NULL) && (blacklist_name[0] != '\0')) || (ip.isBlacklistedAddress())); };
   void reloadHostBlacklist();
   inline const u_int8_t *const get_mac() const {
     return (mac ? mac->get_mac() : NULL);
@@ -921,7 +920,7 @@ class Host : public GenericHashEntry,
   inline HostStats *getStats() { return (stats); }
   void setBlacklistName(char *name);
   inline void blacklistHost(char *blacklist_name) {
-    setBlacklistName(blacklist_name), is_blacklisted = 1;
+    setBlacklistName(blacklist_name);
   }
   virtual void setRxOnlyHost(bool set_it) { is_rx_only = set_it; };
   inline bool resetHostTopSites() {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -285,7 +285,6 @@ void Host::initialize(Mac *_mac, u_int16_t _vlanId,
                                                    changed by deserialize */
   as = NULL, asn = 0, asname = NULL, obs_point = NULL, os = NULL, os_type = os_unknown;
   ssdpLocation = NULL, blacklist_name = NULL, country = NULL;
-  is_blacklisted = false;
 
   memset(&names, 0, sizeof(names));
   memset(view_interface_mac, 0, sizeof(view_interface_mac));
@@ -360,7 +359,6 @@ void Host::initialize(Mac *_mac, u_int16_t _vlanId,
   }
 
   reloadHostBlacklist();
-  is_blacklisted = ip.isBlacklistedAddress();
 }
 
 /* *************************************** */

--- a/src/LuaEngineHost.cpp
+++ b/src/LuaEngineHost.cpp
@@ -174,19 +174,6 @@ static int ntop_host_is_rx_only(lua_State *vm) {
 
 /* **************************************************************** */
 
-static int ntop_host_blacklist(lua_State *vm) {
-  struct ntopngLuaContext *c = getLuaVMContext(vm);
-  Host *h = c ? c->host : NULL;
-
-  if (h) h->blacklistHost();
-
-  lua_pushboolean(vm, h ? true : false);
-
-  return (ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_OK));
-}
-
-/* **************************************************************** */
-
 static int ntop_host_get_bytes_sent(lua_State *vm) {
   struct ntopngLuaContext *c = getLuaVMContext(vm);
   Host *h = c ? c->host : NULL;
@@ -400,8 +387,6 @@ static luaL_Reg _ntop_host_reg[] = {
     {"bytes", ntop_host_get_bytes_total},
     {"l7", ntop_host_get_l7_stats},
     {"score", ntop_host_get_score},
-
-    {"blacklistHost", ntop_host_blacklist},
 
     {"skipVisitedHost", ntop_skip_visited_host},
     {"triggerAlert", ntop_trigger_host_alert},


### PR DESCRIPTION
After checking with the "egrep" command, I found no utilization of the ntop_host_blacklist (blacklistHost) method, so It's possible to remove it. 
