### PR TITLE
Fix change table page on refresh. (#7917)

### DIFF
--- a/http_src/vue/select_table_page.vue
+++ b/http_src/vue/select_table_page.vue
@@ -114,7 +114,9 @@ function back_page() {
 }
 
 function change_active_page(new_active_page, new_start_page_button) {
+  if (new_active_page != null) {
     active_page.value = new_active_page;
+  } 
     // console.log(`new active page: ${new_active_page}`);
     // console.log(`new start page button: ${new_start_page_button}`);
 

--- a/http_src/vue/table.vue
+++ b/http_src/vue/table.vue
@@ -408,7 +408,7 @@ let force_disable_loading = false;
 async function refresh_table(disable_loading) {
     force_refresh = true;
     force_disable_loading = disable_loading || false;
-    select_table_page.value.change_active_page(0, 0);
+    select_table_page.value.change_active_page();
     await nextTick();
     force_refresh = false;
     force_disable_loading = false;


### PR DESCRIPTION
The table will remain on the current page, whether refreshed manually by clicking the icon or automatically.

UPDATE the 'dist' directory after merging and initiating the builds.