### PR TITLE
Add flow exporters filter in aggregated live flows page. (#8047)

### DIFF
--- a/http_src/vue/page-aggregated-live-flows.vue
+++ b/http_src/vue/page-aggregated-live-flows.vue
@@ -208,6 +208,7 @@ function get_url_params() {
     let actual_params = {
         ifid: ntopng_url_manager.get_url_entry("ifid") || props.context.ifid,
         vlan_id: ntopng_url_manager.get_url_entry("vlan_id")  /* No filter by default */,
+        deviceIP: ntopng_url_manager.get_url_entry("deviceIP"),
         aggregation_criteria: ntopng_url_manager.get_url_entry("aggregation_criteria") || selected_criteria.value.param,
         host: ntopng_url_manager.get_url_entry("host") || props.context.host,
     };    

--- a/include/AggregatedFlowsStats.h
+++ b/include/AggregatedFlowsStats.h
@@ -41,6 +41,7 @@ class AggregatedFlowsStats {
   u_int64_t key;
   u_int64_t proto_key;
   bool is_not_guessed;
+  u_int32_t flow_device_ip;
 
  public:
   AggregatedFlowsStats(const IpAddress* c, const IpAddress* s, u_int8_t _l4_proto,
@@ -50,24 +51,27 @@ class AggregatedFlowsStats {
 
 
   /* Getters */
+  inline u_int8_t getL4Protocol() { return (l4_proto); };
+  inline u_int16_t getSrvPort() { return (srv_port); };
+  inline u_int16_t getVlanId() { return vlan_id; };
+  inline u_int16_t getCliVLANId() { return (client ? client->getVLANId() : 0); };
+  inline u_int16_t getSrvVLANId() { return (server ? server->getVLANId() : 0); };
   inline u_int32_t getNumClients() { return (clients.size()); };
   inline u_int32_t getNumServers() { return (servers.size()); };
-  inline u_int8_t getL4Protocol() { return (l4_proto); };
   inline u_int32_t getNumFlows() { return (num_flows); };
-  inline u_int64_t getTotalSent() { return (tot_sent); };
-  inline u_int64_t getTotalRcvd() { return (tot_rcvd); };
   inline u_int32_t getTotalScore() { return (tot_score); };
-  inline u_int16_t getVlanId() { return vlan_id; };
   inline u_int64_t getKey() { return key; };
   inline u_int64_t getProtoKey() { return proto_key; };
+  inline u_int64_t getTotalSent() { return (tot_sent); };
+  inline u_int64_t getTotalRcvd() { return (tot_rcvd); };
   inline char* getProtoName() { return (proto_name ? proto_name : (char *)""); };
   inline char* getInfoKey() { return (info_key ? info_key : (char *)""); };
+ 
   inline const char* getCliIP(char* buf, u_int len) { return (client ? client->getIP(buf, len) : (char *)""); };
   inline const char* getSrvIP(char* buf, u_int len) { return (server ? server->getIP(buf, len) : (char *)""); };
+  
   inline IpAddress* getClientIPaddr() { return(client ? client->getIPaddr() : NULL); }
   inline IpAddress* getServerIPaddr() { return(server ? server->getIPaddr() : NULL); }
-  inline u_int16_t getSrvPort() { return (srv_port); };
-
 
   inline const char* getCliName(char* buf, u_int len) {
     return (client ? client->getHostName(buf, len) : (char *)"");
@@ -81,8 +85,9 @@ class AggregatedFlowsStats {
   inline const char* getSrvIPHex(char* buf, u_int len) {
     return (server ? server->getIPHex(buf, len) : (char *)"");
   };
-  inline u_int16_t getCliVLANId() { return (client ? client->getVLANId() : 0); };
-  inline u_int16_t getSrvVLANId() { return (server ? server->getVLANId() : 0); };
+  inline const char* getFlowDeviceIP(char* buf, u_int len) {
+    return (flow_device_ip != 0 ? Utils::intoaV4(flow_device_ip, buf, len) : (char *)"");
+  };
   inline bool isNotGuessed() { return(is_not_guessed); };
 
   /* Setters */
@@ -104,8 +109,9 @@ class AggregatedFlowsStats {
     if(!server) { server = new (std::nothrow) FlowsHostInfo(_ip, _host); }
   };
   inline void setSrvPort(u_int16_t _srv_port) { srv_port = _srv_port; };
+  inline void setFlowDeviceIP(u_int32_t _flow_device_ip) { flow_device_ip = _flow_device_ip; };
 
-  void setFlowIPVLAN(Flow *f);
+  void setFlowIPVLANDeviceIP(Flow *f);
 
   inline bool isCliInMem() { return (client->isHostInMem()); };
   inline bool isSrvInMem() { return (server->isHostInMem()); };
@@ -121,6 +127,7 @@ struct aggregated_stats {
   std::unordered_map<string, AggregatedFlowsStats *> info_count;
   IpAddress *ip_addr;
   u_int16_t vlan_id;
+  u_int32_t flow_device_ip;
 };
 
 #endif /* _FLOWS_STATS_H_ */

--- a/include/Flow.h
+++ b/include/Flow.h
@@ -928,6 +928,7 @@ class Flow : public GenericHashEntry {
   bool match(AddressTree *ptree);
   bool matchFlowIP(IpAddress *ip, u_int16_t vlan_id);
   bool matchFlowVLAN(u_int16_t vlan_id);
+  bool matchFlowDeviceIP(u_int32_t flow_device_ip);
   void dissectHTTP(bool src2dst_direction, char *payload,
                    u_int16_t payload_len);
   void dissectDNS(bool src2dst_direction, char *payload, u_int16_t payload_len);

--- a/scripts/lua/rest/v2/get/flow/aggregated_live_flows.lua
+++ b/scripts/lua/rest/v2/get/flow/aggregated_live_flows.lua
@@ -23,6 +23,7 @@ end
 
 local ifid = _GET["ifid"]
 local vlan = tonumber(_GET["vlan_id"] or -1)
+local device_ip = _GET["deviceIP"]
 local criteria = _GET["aggregation_criteria"] or ""
 local rc = rest_utils.consts.success.ok
 local filters = {}
@@ -37,6 +38,10 @@ filters["host"] = _GET["host"]
 
 if (vlan) and (isEmptyString(vlan) or tonumber(vlan) == -1) then
    vlan = nil
+end
+
+if (isEmptyString(device_ip)) then
+   device_ip = nil
 end
 
 interface.select(ifid)
@@ -96,8 +101,7 @@ local x = 0
 local aggregated_info = interface.getProtocolFlowsStats(criteria_type_id, filters["page"], filters["sort_column"],
 							filters["sort_order"], filters["start"], filters["length"],
 							ternary(not isEmptyString(filters["map_search"]), filters["map_search"], nil),
-							ternary(filters["host"]~= "", filters["host"], nil), vlan)
-
+							ternary(filters["host"]~= "", filters["host"], nil), vlan, device_ip)
 -- Formatting the data
 for _, data in pairs(aggregated_info or {}) do
    local bytes_sent = data.bytes_sent or 0
@@ -244,6 +248,7 @@ for _, data in pairs(aggregated_info or {}) do
       info = info,
       srv_port = srv_port,
       application = application,
+      device_ip = data.device_ip,
       vlan_id = {
 	 id = nil,
 	 label = nil

--- a/scripts/lua/rest/v2/get/flow/aggregated_live_flows_filters.lua
+++ b/scripts/lua/rest/v2/get/flow/aggregated_live_flows_filters.lua
@@ -5,118 +5,184 @@ local dirs = ntop.getDirs()
 package.path = dirs.installdir .. "/scripts/lua/modules/?.lua;" .. package.path
 package.path = dirs.installdir .. "/scripts/lua/pro/enterprise/modules/?.lua;" .. package.path
 
+-- ##################################################################
+-- Requires
+
 require "lua_utils"
 local rest_utils = require "rest_utils"
 local format_utils = require("format_utils")
 require "lua_utils_get"
 
-if not isAdministratorOrPrintErr() then
-    rest_utils.answer(rest_utils.consts.err.not_granted)
-    return
-end
-
-
-if ntop.isEnterpriseM() then
-    require "aggregate_live_flows"
- end
-
--- =============================
-
+-- ##################################################################
+-- REST params
 
 local ifid = _GET["ifid"]
 local criteria = _GET["aggregation_criteria"] or ""
-local rc = rest_utils.consts.success.ok
-local filters = {}
+local rest_filters = {}
 
+rest_filters["page"] = tonumber(_GET["draw"] or 0)
+rest_filters["sort_column"] = _GET["sort"] or 'flows'
+rest_filters["sort_order"] = _GET["order"] or 'desc'
+rest_filters["start"] = 0
+rest_filters["length"] = 0
+rest_filters["map_search"] = _GET["map_search"]
+rest_filters["host"] = _GET["host"]
 
+-- ##################################################################
+-- Enums
 
+local filter_types = {
+    vlan = 1,
+    flow_device = 2
+}
 
-if isEmptyString(ifid) then
-    ifid = interface.getId()
+-- ##################################################################
+-- Utils functions 
+
+local function retrieve_aggregation_criteria(criteria)
+    
+    -- Aggregation criteria 
+    local criteria_type_id = 1 -- by default application_protocol
+    if criteria == "client" then
+        criteria_type_id = 2
+    elseif criteria == "server" then
+        criteria_type_id = 3
+    elseif criteria == "client_server_srv_port" then
+        criteria_type_id = 7
+    elseif ntop.isEnterpriseM() then
+        local aggregate_live_flows_utils = require "aggregate_live_flows"
+        criteria_type_id = aggregate_live_flows_utils.get_criteria_type_id(criteria)
+    end
+    return criteria_type_id
 end
 
-interface.select(ifid)
+-- ******************************************************************
 
-
-filters["page"] = tonumber(_GET["draw"] or 0)
-filters["sort_column"] = _GET["sort"] or 'flows'
-filters["sort_order"] = _GET["order"] or 'desc'
-filters["start"] = 0
-filters["length"] = 0
-filters["map_search"] = _GET["map_search"]
-filters["host"] = _GET["host"]
--- Aggregation criteria 
-local criteria_type_id = 1 -- by default application_protocol
-if criteria == "client" then
-   criteria_type_id = 2
-elseif criteria == "server" then
-      criteria_type_id = 3
-elseif criteria == "client_server_srv_port" then
-   criteria_type_id = 7
-elseif ntop.isEnterpriseM() then
-   criteria_type_id = get_criteria_type_id(criteria)
-end
-
-local isView = interface.isView()
-local x = 0
-
--- Retrieve the flows
-local aggregated_info = interface.getProtocolFlowsStats(criteria_type_id, filters["page"], filters["sort_column"],
-							filters["sort_order"], filters["start"], filters["length"], ternary(not isEmptyString(filters["map_search"]), filters["map_search"], nil) , ternary(filters["host"]~= "", filters["host"], nil), nil)
-
-local formatted_vlan_filters = {}
-
-local function is_vlan_already_inserted(formatted_vlan_filters, vlan_id)
-    for id,x in ipairs(formatted_vlan_filters) do
-        if(x.value == vlan_id) then
+local function is_filter_already_inserted(filters, filter_id)
+    for id,x in ipairs(filters) do
+        if(x.value == filter_id) then
             return id
         end
     end
     return -1
 end
 
-for _, data in pairs(aggregated_info or {}) do
+-- ******************************************************************
 
-    local index = is_vlan_already_inserted(formatted_vlan_filters, data.vlan_id)
-    if index == -1 then
-        local vlan_name = i18n('no_vlan')
-
-        if data.vlan_id ~= 0 then
-            vlan_name = getFullVlanName(data.vlan_id, true)
-        end
-        local vlan = {
-            count = 1,
-            value = data.vlan_id,
-            label = vlan_name,
-            key = "vlan_id"
-        }
-        formatted_vlan_filters[#formatted_vlan_filters+1] = vlan
-    else
-        formatted_vlan_filters[index].count = formatted_vlan_filters[index].count + 1
+local function get_filter_item_label(element, filter_type)
+    local label
+    if (filter_type == filter_types.vlan) then
+        label = ternary(element~=0, getFullVlanName(element, true), i18n('no_vlan'))
+    elseif (filter_type == filter_types.flow_device) then
+        label = getProbeName(element, false, false)
     end
+
+    return label
 end
 
+-- ******************************************************************
 
+local function get_filter_key(filter_type)
+    local key
+    if (filter_type == filter_types.vlan) then
+        key = "vlan_id"
+    elseif (filter_type == filter_types.flow_device) then
+        key = "deviceIP"
+    end
 
+    return key
+end 
 
-table.sort(formatted_vlan_filters, function(a,b) return a.value < b.value end)
-table.insert(formatted_vlan_filters, 1, {
-    key = "vlan_id",
-    label = i18n('all'),
-    value = ""
-})
+-- ******************************************************************
 
-local rsp = {}
-if (#formatted_vlan_filters > 2) then
-    rsp = {
-        {
-            action = "vlan_id",
-            label = i18n("vlan"),
-            tooltip = i18n("vlan_filter"),
-            name = "vlan_filter",
-            value = formatted_vlan_filters
+local function add_new_filter_item_to_filters_array(filter_id,formatted_filters, filter_type)
+    local index = is_filter_already_inserted(formatted_filters, filter_id)
+    if index == -1 then
+        local filter_label = get_filter_item_label(filter_id, filter_type)
+        local filert_key = get_filter_key(filter_type)
+        local filter_item = {
+            count = 1,
+            value = filter_id,
+            label = filter_label,
+            key = filert_key
         }
-    }
+        formatted_filters[#formatted_filters+1] = filter_item
+    else
+        formatted_filters[index].count = formatted_filters[index].count + 1
+    end
+
 end
 
-rest_utils.answer(rest_utils.consts.success.ok, rsp)
+-- ******************************************************************
+
+local function build_response(criteria)
+    local formatted_vlan_filters = {}
+    local formatted_device_filters = {}
+
+    local criteria_type_id = retrieve_aggregation_criteria(criteria)
+
+    local aggregated_info = interface.getProtocolFlowsStats(criteria_type_id, rest_filters["page"], rest_filters["sort_column"],
+        rest_filters["sort_order"], rest_filters["start"], rest_filters["length"], ternary(not isEmptyString(rest_filters["map_search"]), rest_filters["map_search"], nil) , ternary(rest_filters["host"]~= "", rest_filters["host"], nil), nil)
+
+    for _, data in pairs(aggregated_info or {}) do
+        add_new_filter_item_to_filters_array(data.vlan_id, formatted_vlan_filters,filter_types.vlan)
+        if (not isEmptyString(data.device_ip)) then
+            tprint(data.device_ip)
+            add_new_filter_item_to_filters_array(data.device_ip, formatted_device_filters,filter_types.flow_device)
+        end
+    end
+
+    table.sort(formatted_vlan_filters, function(a,b) return a.value < b.value end)
+    table.insert(formatted_vlan_filters, 1, {
+        key = "vlan_id",
+        label = i18n('all'),
+        value = ""
+    })
+
+    table.sort(formatted_device_filters, function(a,b) return a.value < b.value end)
+    table.insert(formatted_device_filters, 1, {
+        key = "deviceIP",
+        label = i18n("flow_devices.all_flow_devices"),
+        value = ""
+    })
+
+    local rsp = {}
+    if (#formatted_vlan_filters > 2) then
+        rsp[#rsp+1] = {
+                action = "vlan_id",
+                label = i18n("vlan"),
+                tooltip = i18n("vlan_filter"),
+                name = "vlan_filter",
+                value = formatted_vlan_filters
+            }
+    end
+
+    if (#formatted_device_filters > 1) then
+        rsp[#rsp+1] = {
+            action = "deviceIP",
+            label = i18n("flows_page.device_ip"),
+            tooltip = i18n("flows_page.device_ip"),
+            name = "deviceIP",
+            value = formatted_device_filters
+        }
+    end
+    return rsp
+end
+
+-- ##################################################################
+-- Handle REST Response
+
+if isEmptyString(ifid) then
+    ifid = interface.getId()
+end
+
+interface.select(ifid)
+if not isAdministratorOrPrintErr() then
+    rest_utils.answer(rest_utils.consts.err.not_granted)
+end
+
+local respose = build_response(criteria)
+
+rest_utils.answer(rest_utils.consts.success.ok, respose)
+
+-- ##################################################################

--- a/src/AggregatedFlowsStats.cpp
+++ b/src/AggregatedFlowsStats.cpp
@@ -26,7 +26,7 @@
 AggregatedFlowsStats::AggregatedFlowsStats(const IpAddress* c, const IpAddress* s, u_int8_t _l4_proto,
 					   u_int64_t bytes_sent, u_int64_t bytes_rcvd, u_int32_t score) {
   num_flows = tot_sent = tot_rcvd = tot_score =
-  key = vlan_id = proto_key = 0;
+  key = vlan_id = flow_device_ip = proto_key = 0;
   l4_proto = _l4_proto;
   proto_name = info_key = NULL;
   server = client = NULL;
@@ -61,8 +61,9 @@ void AggregatedFlowsStats::incFlowStats(const IpAddress* _client,
 
 /* *************************************** */
 
-void AggregatedFlowsStats::setFlowIPVLAN(Flow *f) {
+void AggregatedFlowsStats::setFlowIPVLANDeviceIP(Flow *f) {
   setClient(f->get_cli_ip_addr(), f->get_cli_host());
   setServer(f->get_srv_ip_addr(), f->get_srv_host());
   setVlanId(f->get_vlan_id());
+  setFlowDeviceIP(f->getFlowDeviceIP());
 }

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -8319,3 +8319,9 @@ bool Flow::matchFlowIP(IpAddress *ip, u_int16_t vlan_id) {
 bool Flow::matchFlowVLAN(u_int16_t vlan_id) {
   return(get_vlan_id() == vlan_id ? true : false);
 }
+
+/* **************************************************** */
+
+bool Flow::matchFlowDeviceIP(u_int32_t flow_device_ip) {
+  return(getFlowDeviceIP() == flow_device_ip ? true : false);
+}


### PR DESCRIPTION
It's possible now to filter the aggregated live flows by the flow exporter device IP.

PLEASE also merge the PR on the pro repository and run "npm run build:ntopngjs" to update the dist.