### PR TITLE
Fix copyright year

### DIFF
--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -215,7 +215,7 @@
 #define MAX_NUM_QUEUED_ADDRS \
   500 /* Maximum number of queued address for resolution */
 #define MAX_NUM_QUEUED_CONTACTS 25000
-#define NTOP_COPYRIGHT "(C) 1998-23 ntop.org"
+#define NTOP_COPYRIGHT "(C) 1998-24 ntop.org"
 #define DEFAULT_PID_PATH "/var/run/ntopng.pid"
 #define SYSTEM_INTERFACE_NAME "__system__"
 #define SYSTEM_INTERFACE_ID -1


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:
Update copyright year from 2023 to 2024

