### PR TITLE
FreeBSD: fix "attempt to concatenate a nil value" in lua script

### DIFF
--- a/scripts/lua/modules/os_utils.lua
+++ b/scripts/lua/modules/os_utils.lua
@@ -82,13 +82,7 @@ function os_utils.execWithOutput(c, ret_code_success)
    
    if(debug) then tprint(c) end
 
-   if(is_freebsd) then
-      f_name = os.tmpname()
-      os.execute(c.." > "..f_name)
-      f = io.open(f_name, 'r')
-   else
-      f = io.popen(c, 'r')
-   end  
+   f = io.popen(c, 'r')
 
    if f == nil then
       return nil, -1


### PR DESCRIPTION
After a fresh installation of ntop under FreeBSD 14 in a jail I got an error message on several pages, e.g. `https://ntop.exmaple.com/lua/if_stats.lua` saying something about `os.tmpname` and/or `nil` value. Since `os.tmpname` should better not be used anyways and a check for an empty `f_name` prevents the function from trying to delete a non-existing file,  `io.tmpfile` can simply be used and works for me.