### PR TITLE
fix building when rrd_tune() function has const char** as the 2nd param

### DIFF
--- a/src/LuaEngineNtop.cpp
+++ b/src/LuaEngineNtop.cpp
@@ -21,6 +21,8 @@
 
 #include "ntop_includes.h"
 
+#include <type_traits>
+
 extern "C" {
 #include "rrd.h"
 };
@@ -6296,7 +6298,7 @@ static int ntop_rrd_tune(lua_State *vm) {
   filename = argv[1];
 
   reset_rrd_state();
-  status = rrd_tune(argc, (char **)argv);
+  status = rrd_tune(argc, (std::conditional<std::is_same<decltype(rrd_tune), int(int, const char **)>::value, const char **, char **>::type)argv);
 
   if (status != 0) {
     char *err = rrd_get_error();


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Describe changes:

These changes are cosmetic and fix compilation with compilers that dislike a direct conversion `const char**` type to `char**`
