### PR TITLE
Fix Missing Src and Dst IP for Elastic Search

### DIFF
--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -3611,16 +3611,17 @@ void Flow::formatECSHost(json_object *my_object, bool is_client,
     if (addr) {
       if (is_client && (getPreNATSrcIp() != getPostNATSrcIp()))
         use_nat = true;
+        tmp_ip.set(getPreNATSrcIp());
 
       /* With NAT they are IPv4 */
-      tmp_ip.set(getPreNATSrcIp());
       json_object_object_add(
 			     host_object,
 			     Utils::jsonLabel(
 					      is_client ? (addr->isIPv4() ? IPV4_SRC_ADDR : IPV6_SRC_ADDR)
 					      : (addr->isIPv4() ? IPV4_DST_ADDR : IPV6_DST_ADDR),
 					      "ip", jsonbuf, sizeof(jsonbuf)),
-			     json_object_new_string(tmp_ip.print(buf, sizeof(buf))));
+			     json_object_new_string(use_nat ? tmp_ip.print(buf, sizeof(buf)) : 
+                               addr->print(buf, sizeof(buf))));
 
       /* Custom information elements, Local, Blacklisted, Has Services and
        * domain name */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):  https://github.com/ntop/ntopng/issues/8664


Describe changes:
It looks like we were using the PreNat IP addresses in the JSON object, even if we weren't using NAT. By default the PreNat addresses were set to 0, causing the src and dst ip address to show up as 0.0.0.0 in elastic search. I added an inline conditional to check whether we are using NAT or not before using the correct IP address.

Also I'm not sure why but the test file in e2e/rest is only passing 27 out of 62 test cases, I checked and this was the case for the main dev branch as well so I assumed nothing broke with my code.



<img width="1425" alt="Screenshot 2024-08-28 at 1 01 29 PM" src="https://github.com/user-attachments/assets/ea83af0a-2812-4451-be75-8255bca36b8f">



