### PR TITLE
Deleted atomic variables for host syn flood counters

### DIFF
--- a/include/Host.h
+++ b/include/Host.h
@@ -94,8 +94,8 @@ class Host : public GenericHashEntry,
   } fin_scan;
 
   struct {
-    std::atomic<u_int32_t> num_active_tcp_flows_as_client, num_established_tcp_flows_as_client; /* (attacker) */
-    std::atomic<u_int32_t> num_active_tcp_flows_as_server, num_established_tcp_flows_as_server; /* (victim) */
+    u_int32_t num_active_tcp_flows_as_client, num_established_tcp_flows_as_client; /* (attacker) */
+    u_int32_t num_active_tcp_flows_as_server, num_established_tcp_flows_as_server; /* (victim) */
   } syn_flood;
 
   /* Need atomic as inc/dec done on different threads */
@@ -605,6 +605,10 @@ class Host : public GenericHashEntry,
 
   u_int32_t syn_flood_victim_hits();
   u_int32_t syn_flood_attacker_hits();
+  inline void reset_syn_flood_hits() {
+    syn_flood.num_active_tcp_flows_as_client = syn_flood.num_active_tcp_flows_as_server =
+      syn_flood.num_established_tcp_flows_as_client = syn_flood.num_established_tcp_flows_as_server = 0;
+  }
 
   inline u_int16_t flow_flood_victim_hits() const {
     return flow_flood.victim_counter ? flow_flood.victim_counter->hits() : 0;
@@ -663,7 +667,7 @@ class Host : public GenericHashEntry,
   };
 
   void incNumFlows(time_t t, bool as_client, bool isTCP);
-  void decNumFlows(time_t t, bool as_client, bool isTCP, u_int16_t isTwhOver);
+  void decNumFlows(time_t t, bool as_client);
   void incNumEstablishedTCPFlows(bool as_client);
 
   inline void incNumAlertedFlows(bool as_client) {

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -422,7 +422,7 @@ Flow::~Flow() {
 
   if (cli_u) {
     cli_u->decUses(); /* Decrease the number of uses */
-    cli_u->decNumFlows(get_last_seen(), true, isTCP(), twh_over);
+    cli_u->decNumFlows(get_last_seen(), true);
 
     if (is_oneway_tcp_udp_flow) cli_u->incUnidirectionalEgressTCPUDPFlows();
   }
@@ -433,7 +433,7 @@ Flow::~Flow() {
 
   if (srv_u) {
     srv_u->decUses(); /* Decrease the number of uses */
-    srv_u->decNumFlows(get_last_seen(), false, isTCP(), twh_over);
+    srv_u->decNumFlows(get_last_seen(), false);
 
     if (is_oneway_tcp_udp_flow) {
       srv_u->incUnidirectionalIngressTCPUDPFlows();
@@ -5472,10 +5472,10 @@ void Flow::updateTcpFlags(const struct bpf_timeval *when, u_int8_t flags,
       if (flags_3wh == TH_SYN) {
         if (synTime.tv_sec == 0) memcpy(&synTime, when, sizeof(struct timeval));
 
-	if((src2dst_tcp_flags & (TH_SYN | TH_ACK)) == (TH_SYN | TH_ACK)) {
-	  /* SYN|ACK arrived before SYN */
-	  swap_requested = true;
-	}
+	      if((src2dst_tcp_flags & (TH_SYN | TH_ACK)) == (TH_SYN | TH_ACK)) {
+	        /* SYN|ACK arrived before SYN */
+	        swap_requested = true;
+	      }
       } else if (flags_3wh == (TH_SYN | TH_ACK)) {
         if ((synAckTime.tv_sec == 0) && (synTime.tv_sec > 0)) {
           memcpy(&synAckTime, when, sizeof(struct timeval));
@@ -8517,8 +8517,8 @@ void Flow::swap() {
     /* Not a view interface */
     Host *h = cli_host;
     
-    cli_host->decNumFlows(now, true /* as client */, isTCP(), twh_over),
-      srv_host->decNumFlows(now, false /* as server */, isTCP(), twh_over);
+    cli_host->decNumFlows(now, true /* as client */);
+      srv_host->decNumFlows(now, false /* as server */);
     cli_host = srv_host, cli_ip_addr = srv_ip_addr;
     srv_host = h, srv_ip_addr = i;
     cli_host->incNumFlows(now, true /* as client */, isTCP()),

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1518,40 +1518,11 @@ void Host::incNumFlows(time_t t, bool as_client, bool isTCP) {
 
 /* *************************************** */
 
-void Host::decNumFlows(time_t t, bool as_client, bool isTCP,
-                       u_int16_t isTwhOver) {
+void Host::decNumFlows(time_t t, bool as_client) { 
   if (as_client)
     num_active_flows_as_client--;
   else
     num_active_flows_as_server--;
-
-  if (isTCP) {
-    if (as_client) {
-      if(syn_flood.num_active_tcp_flows_as_client == 0)
-	ntop->getTrace()->traceEvent(TRACE_WARNING, "Internel error [client]");
-      else
-	syn_flood.num_active_tcp_flows_as_client--;
-      
-      if (isTwhOver) {
-	if(syn_flood.num_established_tcp_flows_as_client == 0)
-	  ntop->getTrace()->traceEvent(TRACE_WARNING, "Internel error [client]");
-	else
-	  syn_flood.num_established_tcp_flows_as_client--;
-      }
-    } else {
-      if(syn_flood.num_active_tcp_flows_as_server == 0)
-	ntop->getTrace()->traceEvent(TRACE_WARNING, "Internel error [server]");
-      else
-	syn_flood.num_active_tcp_flows_as_server--;
-      
-      if (isTwhOver) {
-	if(syn_flood.num_established_tcp_flows_as_server == 0)
-	  ntop->getTrace()->traceEvent(TRACE_WARNING, "Internel error [server]");
-	else
-	  syn_flood.num_established_tcp_flows_as_server--;
-      }
-    }
-  }
 }
 
 /* *************************************** */

--- a/src/host_checks/SYNFlood.cpp
+++ b/src/host_checks/SYNFlood.cpp
@@ -42,6 +42,9 @@ void SYNFlood::periodicUpdate(Host *h, HostAlert *engaged_alert) {
   else if ((hits = h->syn_flood_victim_hits()) > t_shold)
     triggerFlowHitsAlert(h, engaged_alert, false, hits, t_shold,
                          CLIENT_NO_RISK_PERCENTAGE);
+
+  /* Reset counters once done */
+  h->reset_syn_flood_hits();
 }
 
 /* ***************************************************** */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [ x ] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ x ] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ x ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:
Instead of decreasing the counters every time a flow is deleted, reset the syn_flood counters every minute when the syn_flood check is called. 
This way, the logic remains the same and the counters are only updated by the same thread.