### PR TITLE
Fixed missing user agent info in historical flow details

### DIFF
--- a/scripts/lua/modules/lua_utils_gui.lua
+++ b/scripts/lua/modules/lua_utils_gui.lua
@@ -1237,6 +1237,14 @@ function format_http_info(http_info, no_html)
         end
     end
 
+    if http_info["last_user_agent"] then
+        if no_html then
+          http_info["last_user_agent"] = http_info["last_user_agent"]
+        else
+          http_info["last_user_agent"] = string.format('<span">%s</span>', http_info["last_user_agent"])
+        end
+      end
+
     return http_info
 end
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [ x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [ x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):
User agent information was previously missing from historical flow information.