### PR TITLE
Introducing ntopng Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/ntop/ntopng/build.yml?branch=dev&logo=github)](https://github.com/ntop/ntopng/actions?query=workflow%3ABuild)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/ntopng.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:ntopng)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20ntopng%20Guru-006BFF)](https://gurubase.io/g/ntopng)
 
 ### Introduction
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ntopng Guru](https://gurubase.io/g/ntopng) to Gurubase. ntopng Guru uses the data from this repo and data from the [docs](https://www.ntop.org/guides/ntopng/) to answer questions by leveraging the LLM.

In this PR, I showcased the "ntopng Guru", which highlights that ntopng now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ntopng Guru in Gurubase, just let me know that's totally fine.
