### PR TITLE
Added application latency in historical flow information

### DIFF
--- a/scripts/lua/modules/historical_flow_details_formatter.lua
+++ b/scripts/lua/modules/historical_flow_details_formatter.lua
@@ -524,6 +524,15 @@ end
 
 -- ###############################################
 
+local function format_historical_application_latency(latency)
+    return {
+        name = i18n("flow_details.application_latency"),
+        values = {(tonumber(latency)) .. " ms"}
+    }
+end
+
+-- ###############################################
+
 local function format_historical_obs_point(flow)
     return {
         name = i18n("db_explorer.observation_point"),
@@ -696,6 +705,10 @@ function historical_flow_details_formatter.formatHistoricalFlowDetails(flow)
             flow_details[#flow_details + 1] = format_historical_latency(flow, "SERVER_NW_LATENCY_US", "srv")
         end
         local alert_json = json.decode(flow["ALERT_JSON"] or '') or {}
+
+        if (alert_json["appl_latency"]) then
+            flow_details[#flow_details + 1] = format_historical_application_latency(alert_json["appl_latency"])
+        end
 
         if (alert_json["traffic_stats"] and table.len(alert_json["traffic_stats"]) > 0) then
             local rowspan = 1;

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -8131,9 +8131,11 @@ void Flow::getProtocolJSONInfo(ndpi_serializer *serializer) {
       // srv2cli.lost
       ndpi_serialize_string_uint32(serializer, "srv2cli_lost",
 				   getTrafficStats()->get_srv2cli_tcp_lost());
-
     ndpi_serialize_end_of_block(serializer); /* traffic_stats block */
   }
+
+  if(protocol == IPPROTO_TCP && applLatencyMsec > 0)
+      ndpi_serialize_string_float(serializer, "appl_latency", applLatencyMsec, "%.2f");
 
   if(alert_score.size() > 0) {
     ndpi_serialize_start_of_block(serializer, "alert_score");


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):
7883

Describe changes:
Added Application Latency information in historical flow details.

