### PR TITLE
Fixes mdns_name handling by escaping single quotes in asset values

### DIFF
--- a/src/LocalHost.cpp
+++ b/src/LocalHost.cpp
@@ -897,6 +897,18 @@ bool LocalHost::addDataToAssets(char *_field, char *_value) {
   if (_field && _field[0] != '\0' && _value && _value[0] != '\0') {
     std::string field = _field;
     std::string value = _value;
+    if (strcmp(_field, "mdns_name") == 0) {
+      size_t pos = 0;
+      while ((pos = value.find("'", pos)) != std::string::npos) {
+        // Check if the next character is also a quote
+        if ((pos + 1 < value.size()) && value[pos + 1] == '\'') {
+          pos += 2; // Skip already doubled quotes
+        } else {
+          value.insert(pos, "'");
+          pos += 2;
+        }
+      }
+    }
     asset_map[field] = value;
     asset_map_updated = true; /* Next time dump data */
     return true;


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe bug:
SQL assets insertion yield an error when inside a "mdns_name" field value is present a single quote
![image](https://github.com/user-attachments/assets/24d44e2d-9505-4b4e-bbfe-be9557238b04)


