### PR TITLE
Fixed the reset user password check in the user API rest

### DIFF
--- a/scripts/lua/rest/v2/edit/ntopng/user.lua
+++ b/scripts/lua/rest/v2/edit/ntopng/user.lua
@@ -126,8 +126,9 @@ if(password ~= nil and confirm_password ~= nil) then
       return
    end
 
-   if(ntop.resetUserPassword(_SESSION["user"], username, "", password)) then
+   if(not ntop.resetUserPassword(_SESSION["user"], username, "", password)) then
       rest_utils.answer(rest_utils.consts.err.edit_user_failed, res)
+      return
    end
 end
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:
Fixed the reset user password check in the user API rest


