### PR TITLE
fix application link from flow_details to flows_stats

### DIFF
--- a/scripts/lua/flow_details.lua
+++ b/scripts/lua/flow_details.lua
@@ -599,7 +599,7 @@ else
       if ((flow.client_process ~= nil) or (flow.server_process ~= nil)) then
          print("s")
       end
-      print("flows_stats.lua?application=" .. flow["proto.ndpi"] .. "\">")
+      print("flows_stats.lua?application=" .. flow["proto.ndpi_id"] .. "\">")
       print(getApplicationLabel(flow["proto.ndpi"], 32) .. "</A> ")
 
       print("(<A HREF=\"" .. ntop.getHttpPrefix() .. "/lua/")


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

Change flow_details to link to the flows_stats page using the application id, rather than the application name.

