### PR TITLE
if the hasProtoFile is false, then the new_rule_type is undefined, so default to group

### DIFF
--- a/scripts/lua/flow_details.lua
+++ b/scripts/lua/flow_details.lua
@@ -365,8 +365,8 @@ local function printAddCustomHostRule(full_url)
 
    print [[<script>
    function addToCustomizedCategories() {
-      var is_category = ($("#new_rule_type").val() == "category");
-      var target_value = is_category ? $("#flow_target_category").val() : $("#flow_target_app").val();;
+      var is_category = ($("#new_rule_type").val() === undefined || $("#new_rule_type").val() == "category");
+      var target_value = is_category ? $("#flow_target_category").val() : $("#flow_target_app").val();
       var target_url = NtopUtils.cleanCustomHostUrl($("#categories_url_add").val());
 
       if(!target_value || !target_url)


### PR DESCRIPTION
Signed-off-by: Ryan Winter <ryanwinter@outlook.com>

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

When adding a domain to a host rule, if the hasProtoFile returned false, then the new_rule_type was undefined, and saving the rule would default to App and fail.
