### PR TITLE
Added sha256, sha384, sha512 authentication protocols in the Add SNMP Device interface

### DIFF
--- a/http_src/vue/modal-add-snmp-device.vue
+++ b/http_src/vue/modal-add-snmp-device.vue
@@ -224,6 +224,9 @@ const selected_auth_protocol = ref(null);
 const snmp_auth_protocols = ref([
   { id: "md5", label: "MD5" },
   { id: "sha", label: "SHA" },
+  { id: "sha256", label: "SHA256" },
+  { id: "sha384", label: "SHA384" },
+  { id: "sha512", label: "SHA512" },
 ]);
 
 const snmp_privacy_protocols = ref([

--- a/scripts/lua/modules/http_lint.lua
+++ b/scripts/lua/modules/http_lint.lua
@@ -748,7 +748,7 @@ local function validateSnmpLevel(level)
 end
 
 local function validateSnmpAuthProtocol(protocol)
-    local protocols = {"md5", "sha"}
+    local protocols = {"md5", "sha","sha256","sha384","sha512"}
     return validateChoice(protocols, protocol)
 end
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues/8953):


Describe changes:
Added sha256, sha384, sha512 authentication protocols in the Add SNMP Device interface
<img width="900" alt="immagine" src="https://github.com/user-attachments/assets/a2f4788d-05ed-4282-a551-64d85a67b909" />


