### PR TITLE
Fixed syslog producers table not working #9039

### DIFF
--- a/scripts/lua/syslog_producers.lua
+++ b/scripts/lua/syslog_producers.lua
@@ -28,6 +28,7 @@ for k,v in pairs(syslog_scripts) do
   table.insert(producer_types, { title = i18n(v.."_collector.title"), value = v  })
 end
 
+tprint(syslog_scripts)
 -- #######################################################
 
 -- Title
@@ -347,7 +348,20 @@ print([[
           ajax: {
               url: `${http_prefix}/lua/rest/v2/get/syslog/producer/list.lua?ifid=]] .. ifid .. [[`,
               type: 'get',
-              dataSrc: ''
+              dataSrc: function(json) {
+
+                  if (!Array.isArray(json)) {
+                      if (typeof json === 'object') {
+                          return json.rsp; // return rsp as new rest API have been changed
+                      }
+
+                      return [];
+                  }
+                  
+                  return json;
+              },error: function(xhr, error, thrown) {
+                  console.error("Error:", error, thrown);
+              }
           },
           buttons: {
               buttons: [

--- a/scripts/lua/syslog_producers.lua
+++ b/scripts/lua/syslog_producers.lua
@@ -28,7 +28,6 @@ for k,v in pairs(syslog_scripts) do
   table.insert(producer_types, { title = i18n(v.."_collector.title"), value = v  })
 end
 
-tprint(syslog_scripts)
 -- #######################################################
 
 -- Title


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:
v2 rest have to extract `rsp` field to build the table, which was missing in this page.

<img width="1034" alt="Screenshot 2025-03-17 at 16 26 58" src="https://github.com/user-attachments/assets/d4006829-4785-440d-8f91-2acc9b695d25" />
