### PR TITLE
Added dashboard url in assets navbar, fixed online status badge

### DIFF
--- a/http_src/vue/page-assets.vue
+++ b/http_src/vue/page-assets.vue
@@ -165,6 +165,7 @@ const map_table_def_columns = (columns) => {
             let host_icon = `<a href='/lua/host_details.lua?host=${row.host.ip}' data-bs-toggle='tooltip' data-bs-placement='top' title='Host Details'><i class='fas fa-laptop'></i></a>`;
             
             if (is_asset_online) {
+                console.log("Asset is online: ", `<a href="${host_url}">${ip_address}</a> ${host_icon} ${icons}`)
                 return `<a href="${host_url}">${ip_address}</a> ${host_icon} ${icons}`
             }
 
@@ -198,7 +199,8 @@ const map_table_def_columns = (columns) => {
         },
         "status": (value, row) => {
             let badge = `<span class="badge bg-secondary">${i18n('asset_details.offline')}</span>`
-            if (row.last_seen.timestamp == 0) {
+
+            if (row.online) {
                 badge = `<span class="badge bg-success">${i18n('asset_details.online')}</span>`
             }
             return badge

--- a/scripts/lua/assets.lua
+++ b/scripts/lua/assets.lua
@@ -11,7 +11,7 @@ local json = require("dkjson")
 
 sendHTTPContentTypeHeader('text/html')
 
-local page = _GET["page"] or "overview"
+local page = _GET["page"]
 
 page_utils.print_header_and_set_active_menu_entry(page_utils.menu_entries.assets)
 
@@ -20,12 +20,20 @@ dofile(dirs.installdir .. "/scripts/lua/inc/menu.lua")
 -- ######################################   
 
 local base_url = ntop.getHttpPrefix() .. "/lua/assets.lua"
+
 page_utils.print_navbar(i18n("assets"), base_url .. "?", {
     {
         active = page == "details" or page == nil,
         page_name = "details",
-        label = i18n("details.details")
-    }
+        label = "<i class=\"fas fa-lg fa-home\"></i>"
+    },
+    {   -- redirect to dashboard if clickhouse is enabled and ntopng is pro version
+        hidden = (not ntop.isClickHouseEnabled()) and (not ntop.isPro()),
+        active = page == "dashboard",
+        page_name = "dashboard",
+        label = i18n("index_page.dashboard"),
+        url = ntop.getHttpPrefix() .. "/lua/pro/assets_dashboard.lua"
+    },
 })
 
 -- ######################################    


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

Added dashboard url in assets navbar, fixed online status badge
<img width="592" alt="Screenshot 2025-03-18 at 18 26 44" src="https://github.com/user-attachments/assets/422e40ec-fe25-4030-997d-da48a733f3c8" />
