### PR TITLE
fix compilation error when building with dynamic nDPI

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -79,6 +79,10 @@ return 0;
 AC_ARG_WITH(hiredis, AS_HELP_STRING([--without-hiredis], [Build without hiredis integration]), [with_hiredis=no], [with_hiredis=yes])
 AC_ARG_WITH(dynamic_ndpi, AS_HELP_STRING([--with-dynamic-ndpi], [Build with dynamic ndpi]), [with_dynamic_ndpi=yes], [with_dynamic_ndpi=no])
 
+if test "$with_dynamic_ndpi" = "yes"; then
+  AC_DEFINE([HAVE_DYNAMIC_NDPI], [1], [Define if using dynamic linking with nDPI])
+fi
+
 dnl> CLANG_STDLIB="-stdlib=libc++"
 
 dnl> On Ubuntu do sudo apt-get install -y clang-14  clang-tools-14

--- a/include/ntop_includes.h
+++ b/include/ntop_includes.h
@@ -119,7 +119,12 @@ extern "C" {
 #include <pcap/bpf.h> /* Used for bpf_filter() */
 #endif
 
+#ifdef HAVE_DYNAMIC_NDPI
+#include <ndpi/ndpi_api.h>
+#else
 #include "ndpi_api.h"
+#endif
+
 #include "lua.h"
 #include "lauxlib.h"
 #include "lualib.h"


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues): #9242


Describe changes:


Fix compilation error when building with dynamic nDPI library (`ndpi_api.h` and the library in this case is not in the same directory and it is needed to use `#include <ndpi/ndpi_api.h>` instead of `#include "ndpi_api.h"`)