### PR TITLE
Implement traffic quota serialization/deserialization on shutdown/startup

### DIFF
--- a/include/HostPools.h
+++ b/include/HostPools.h
@@ -52,6 +52,7 @@ class HostPools {
     return stats[host_pool_id];
   }
   void reloadPoolStats();
+  void storeStats(HostPoolStats **stats);
   static void deleteStats(HostPoolStats ***hps);
 
   void swap(VLANAddressTree *new_trees, HostPoolStats **new_stats);

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -756,7 +756,6 @@
 #define HOST_POOL_MEMBERS_KEY NTOPNG_PREFS_PREFIX ".host_pools.members.%s"
 #define HOST_POOL_SHAPERS_KEY NTOPNG_PREFS_PREFIX ".%u.l7_policies.%s"
 #define HOST_POOL_DETAILS_KEY NTOPNG_PREFS_PREFIX ".host_pools.details.%u"
-#define HOST_POOL_LAST_CHECK_EPOCH_KEY NTOPNG_PREFS_PREFIX ".host_pools.last_check_epoch"
 #define CONST_SUBINTERFACES_PREFS NTOPNG_PREFS_PREFIX ".%u.sub_interfaces"
 #define CONST_PREFS_CLIENT_X509_AUTH \
   NTOPNG_PREFS_PREFIX ".is_client_x509_auth_enabled"

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -756,6 +756,8 @@
 #define HOST_POOL_MEMBERS_KEY NTOPNG_PREFS_PREFIX ".host_pools.members.%s"
 #define HOST_POOL_SHAPERS_KEY NTOPNG_PREFS_PREFIX ".%u.l7_policies.%s"
 #define HOST_POOL_DETAILS_KEY NTOPNG_PREFS_PREFIX ".host_pools.details.%u"
+#define HOST_POOL_STATS_KEY NTOPNG_PREFS_PREFIX ".host_pools.stats.ifid_%u.pool_%u"
+#define HOST_POOL_LAST_CHECK_DATE_KEY NTOPNG_PREFS_PREFIX ".host_pools.last_check_day"
 #define CONST_SUBINTERFACES_PREFS NTOPNG_PREFS_PREFIX ".%u.sub_interfaces"
 #define CONST_PREFS_CLIENT_X509_AUTH \
   NTOPNG_PREFS_PREFIX ".is_client_x509_auth_enabled"

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -757,7 +757,7 @@
 #define HOST_POOL_SHAPERS_KEY NTOPNG_PREFS_PREFIX ".%u.l7_policies.%s"
 #define HOST_POOL_DETAILS_KEY NTOPNG_PREFS_PREFIX ".host_pools.details.%u"
 #define HOST_POOL_STATS_KEY NTOPNG_PREFS_PREFIX ".host_pools.stats.ifid_%u.pool_%u"
-#define HOST_POOL_LAST_CHECK_DATE_KEY NTOPNG_PREFS_PREFIX ".host_pools.last_check_day"
+#define HOST_POOL_LAST_CHECK_EPOCH_KEY NTOPNG_PREFS_PREFIX ".host_pools.last_check_epoch"
 #define CONST_SUBINTERFACES_PREFS NTOPNG_PREFS_PREFIX ".%u.sub_interfaces"
 #define CONST_PREFS_CLIENT_X509_AUTH \
   NTOPNG_PREFS_PREFIX ".is_client_x509_auth_enabled"

--- a/include/ntop_defines.h
+++ b/include/ntop_defines.h
@@ -756,7 +756,6 @@
 #define HOST_POOL_MEMBERS_KEY NTOPNG_PREFS_PREFIX ".host_pools.members.%s"
 #define HOST_POOL_SHAPERS_KEY NTOPNG_PREFS_PREFIX ".%u.l7_policies.%s"
 #define HOST_POOL_DETAILS_KEY NTOPNG_PREFS_PREFIX ".host_pools.details.%u"
-#define HOST_POOL_STATS_KEY NTOPNG_PREFS_PREFIX ".host_pools.stats.ifid_%u.pool_%u"
 #define HOST_POOL_LAST_CHECK_EPOCH_KEY NTOPNG_PREFS_PREFIX ".host_pools.last_check_epoch"
 #define CONST_SUBINTERFACES_PREFS NTOPNG_PREFS_PREFIX ".%u.sub_interfaces"
 #define CONST_PREFS_CLIENT_X509_AUTH \

--- a/scripts/callbacks/system/startup.lua
+++ b/scripts/callbacks/system/startup.lua
@@ -346,6 +346,9 @@ if not ntop.isnEdge() then
     -- may be not yet up at this stage
     blog_utils.fetchLatestPosts()
 end
+if ntop.isnEdge() then
+    host_pools_nedge.startupCheckResetPoolsQuotas()
+end
 
 -- Cleanup old influxdb files (if any)
 local influxdb_dir = dirs.workingdir .. "/tmp/influxdb"

--- a/scripts/callbacks/system/startup.lua
+++ b/scripts/callbacks/system/startup.lua
@@ -347,7 +347,9 @@ if not ntop.isnEdge() then
     blog_utils.fetchLatestPosts()
 end
 if ntop.isnEdge() then
+    interface.select(tostring(interface.getFirstInterfaceId()))
     host_pools_nedge.startupCheckResetPoolsQuotas()
+    interface.select(getSystemInterfaceId())
 end
 
 -- Cleanup old influxdb files (if any)

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -457,9 +457,11 @@ function host_pools_nedge.resetPoolsQuotas(pool_filter)
   else
     keys_to_del = ntop.getHashKeysCache(serialized_key) or {}
   end
+  -- Delete the redis serialization
   for key in pairs(keys_to_del) do
     ntop.delHashCache(serialized_key, tostring(key))
   end
+    -- Delete the in-memory stats
   interface.resetPoolsQuotas(pool_filter)
 end
 
@@ -491,7 +493,11 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
       end
     elseif quotas_control.reset == "weekly" then
       -- Sunday = 1, Monday = 2, ...
+      -- Check if the last check and current date are in the same month and year 
       if last_check_date.month == actual_date.month and last_check_date.year == actual_date.year then
+          -- Prevent reset if:
+          -- It's Sunday today (start of the week), or the weekday has progressed but we're still in the same week
+          -- AND less than a full week (7 days) has passed since the last check
         if (actual_date.wday == 1 
             or (last_check_date.wday ~= 1 and actual_date.wday >= last_check_date.wday)) 
             and math.floor(diff /(7 * 24 * 60 * 60)) <= 0 then
@@ -514,12 +520,8 @@ function host_pools_nedge.dailyCheckResetPoolsQuotas()
   local shapers_config = nf_config:getShapersConfig()
   local quotas_control = shapers_config.quotas_control
   local do_reset = true
-  if quotas_control.reset == "daily" then 
-    local data = os.date("*t", timestamp)
-    if data.hour ~= 0 and data.min ~= 0 then
-      do_reset = false
-    end
-  elseif quotas_control.reset == "monthly" then
+
+  if quotas_control.reset == "monthly" then
     local day_of_month = os.date("*t").day
 
     if day_of_month ~= 1 --[[ First day of the month --]] then

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -71,8 +71,8 @@ local function get_pool_details_key(pool_id)
   return string.format("ntopng.prefs.host_pools.details.%d", tonumber(pool_id))
 end
 
-local function get_pools_serialized_key(ifid)
-  return "ntopng.serialized_host_pools.ifid_" .. ifid
+local function get_pools_serialized_key(ifid, pool_id)
+  return "ntopng.prefs.host_pools.stats.ifid_" .. ifid .. ".pool_" .. pool_id
 end
 
 function host_pools_nedge.getPoolDetail(pool_id, detail)
@@ -448,22 +448,49 @@ function host_pools_nedge.printQuotas(pool_id, host, page_params)
 end
 
 function host_pools_nedge.resetPoolsQuotas(pool_filter)
-  local serialized_key = get_pools_serialized_key(tostring(interface.getFirstInterfaceId()))
-  local keys_to_del
+  local pools = host_pools_nedge.getPoolsList()
+  for _, v in ipairs(pools) do
+    local serialized_key = get_pools_serialized_key(tostring(interface.getFirstInterfaceId()), v.id)
+    ntop.delCache(serialized_key)
+    interface.resetPoolsQuotas(v.id)
+  end
+end
 
-  if pool_filter ~= nil then
-    keys_to_del = {[pool_filter]=1, }
+function host_pools_nedge.startupCheckResetPoolsQuotas()
+  package.path = dirs.installdir .. "/pro/scripts/lua/nedge/modules/system_config/?.lua;" .. package.path
+  local nf_config = require("nf_config"):create()
+  local shapers_config = nf_config:getShapersConfig()
+  local quotas_control = shapers_config.quotas_control
+  local do_reset = true
+  local last_check_day = ntop.getCache("ntopng.prefs.host_pools.last_check_day")
+
+  local t1 = tonumber(last_check_str) or 0
+  if t1 == 0 then
+    ntop.setCache("ntopng.prefs.host_pools.last_check_day", tostring(os.time()))
   else
-    keys_to_del = ntop.getHashKeysCache(serialized_key) or {}
+    local t2 = os.time(os.date())
+    local diff = os.difftime(timestamp2, timestamp1)
+    
+    if quotas_control.reset == "daily" then 
+      local days = math.floor(diff / (60 * 60 * 24))
+      if days <= 0 then
+        do_reset = false
+      end
+    elseif quotas_control.reset == "monthly" then
+      if last_check_day.month == os.date().month then
+        do_reset = false
+      end
+    elseif quotas_control.reset == "weekly" then
+      local weeks = math.floor(diff /(7 * 24 * 60 * 60))
+      if weeks <=0 then
+        do_reset = false
+      end
+    end
+    if do_reset then
+      host_pools_nedge.resetPoolsQuotas()
+      ntop.setCache("ntopng.prefs.host_pools.last_check_day", tostring(os.time()))
+    end
   end
-
-  -- Delete the redis serialization
-  for key in pairs(keys_to_del) do
-    ntop.delHashCache(serialized_key, tostring(key))
-  end
-
-  -- Delete the in-memory stats
-  interface.resetPoolsQuotas(pool_filter)
 end
 
 -- @brief Performs a daily check and possibly resets host quotas.
@@ -474,23 +501,28 @@ function host_pools_nedge.dailyCheckResetPoolsQuotas()
   local shapers_config = nf_config:getShapersConfig()
   local quotas_control = shapers_config.quotas_control
   local do_reset = true
+  if quotas_control.reset == "daily" then 
+    local data = os.date("*t", timestamp)
+    if data.hour ~= 0 and data.min ~= 0 then
+      do_reset = false
+    end
+  elseif quotas_control.reset == "monthly" then
+    local day_of_month = os.date("*t").day
 
-  if quotas_control.reset == "monthly" then
-     local day_of_month = os.date("*t").day
-
-     if day_of_month ~= 1 --[[ First day of the month --]] then
-	do_reset = false
-     end
+    if day_of_month ~= 1 --[[ First day of the month --]] then
+	    do_reset = false
+    end
   elseif quotas_control.reset == "weekly" then
-     local day_of_week = os.date("*t").wday
+    local day_of_week = os.date("*t").wday
 
-     if day_of_week ~= 2 --[[ Monday --]] then
-	do_reset = false
-     end
+    if day_of_week ~= 2 --[[ Monday --]] then
+	    do_reset = false
+    end
   end
 
   if do_reset then
-     host_pools_nedge.resetPoolsQuotas()
+    host_pools_nedge.resetPoolsQuotas()
+    ntop.setCache("ntopng.prefs.host_pools.last_check_day", tostring(os.time()))
   end
 end
 

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -71,8 +71,8 @@ local function get_pool_details_key(pool_id)
   return string.format("ntopng.prefs.host_pools.details.%d", tonumber(pool_id))
 end
 
-local function get_pools_serialized_key(ifid, pool_id)
-  return "ntopng.prefs.host_pools.stats.ifid_" .. ifid .. ".pool_" .. pool_id
+local function get_pools_serialized_key(ifid)
+  return "ntopng.serialized_host_pools.ifid_" .. ifid
 end
 
 function host_pools_nedge.getPoolDetail(pool_id, detail)
@@ -447,14 +447,22 @@ function host_pools_nedge.printQuotas(pool_id, host, page_params)
 
 end
 
-function host_pools_nedge.resetPoolsQuotas()
-  local pools = host_pools_nedge.getPoolsList()
-  for _, v in ipairs(pools) do
-    local serialized_key = get_pools_serialized_key(tostring(interface.getFirstInterfaceId()), v.id)
-    ntop.delCache(serialized_key)
-    interface.resetPoolsQuotas(v.id)
+function host_pools_nedge.resetPoolsQuotas(pool_filter)
+
+  local serialized_key = get_pools_serialized_key(tostring(interface.getFirstInterfaceId()))
+  local keys_to_del
+
+  if pool_filter ~= nil then
+    keys_to_del = {[pool_filter]=1, }
+  else
+    keys_to_del = ntop.getHashKeysCache(serialized_key) or {}
   end
+  for key in pairs(keys_to_del) do
+    ntop.delHashCache(serialized_key, tostring(key))
+  end
+  interface.resetPoolsQuotas(pool_filter)
 end
+
 
 function host_pools_nedge.startupCheckResetPoolsQuotas()
   package.path = dirs.installdir .. "/pro/scripts/lua/nedge/modules/system_config/?.lua;" .. package.path
@@ -462,28 +470,33 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
   local shapers_config = nf_config:getShapersConfig()
   local quotas_control = shapers_config.quotas_control
   local do_reset = true
-  local last_check_day = ntop.getCache("ntopng.prefs.host_pools.last_check_epoch")
+  local last_check_epoch_cache = ntop.getCache("ntopng.prefs.host_pools.last_check_epoch")
 
-  local t1 = tonumber(last_check_str) or 0
-  if t1 == 0 then
+  local last_check_epoch = tonumber(last_check_epoch_cache) or 0
+  if last_check_epoch == 0 then
     ntop.setCache("ntopng.prefs.host_pools.last_check_epoch", tostring(os.time()))
   else
-    local t2 = os.time(os.date())
-    local diff = os.difftime(timestamp2, timestamp1)
-    
+    local last_check_date = os.date("*t", last_check_epoch)
+    local actual_time = os.time()
+    local actual_date = os.date("*t", actual_time)
+    local diff = os.difftime(actual_time, last_check_epoch)
     if quotas_control.reset == "daily" then 
       local days = math.floor(diff / (60 * 60 * 24))
       if days <= 0 then
         do_reset = false
       end
     elseif quotas_control.reset == "monthly" then
-      if last_check_day.month == os.date().month then
+      if last_check_date.month == actual_date.month and last_check_date.year == actual_date.year then
         do_reset = false
       end
     elseif quotas_control.reset == "weekly" then
-      local weeks = math.floor(diff /(7 * 24 * 60 * 60))
-      if weeks <=0 then
-        do_reset = false
+      -- Sunday = 1, Monday = 2, ...
+      if last_check_date.month == actual_date.month and last_check_date.year == actual_date.year then
+        if (actual_date.wday == 1 
+            or (last_check_date.wday ~= 1 and actual_date.wday >= last_check_date.wday)) 
+            and math.floor(diff /(7 * 24 * 60 * 60)) <= 0 then
+          do_reset = false
+        end
       end
     end
     if do_reset then

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -483,8 +483,9 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
     local actual_date = os.date("*t", actual_time)
     local diff = os.difftime(actual_time, last_check_epoch)
     if quotas_control.reset == "daily" then 
-      local days = math.floor(diff / (60 * 60 * 24))
-      if days <= 0 then
+      if last_check_date.month == actual_date.month 
+          and last_check_date.year == actual_date.year 
+          and last_check_date.day == actual_date.day then
         do_reset = false
       end
     elseif quotas_control.reset == "monthly" then
@@ -492,17 +493,18 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
         do_reset = false
       end
     elseif quotas_control.reset == "weekly" then
-      -- Sunday = 1, Monday = 2, ...
-      -- Check if the last check and current date are in the same month and year 
-      if last_check_date.month == actual_date.month and last_check_date.year == actual_date.year then
-          -- Prevent reset if:
-          -- It's Sunday today (start of the week), or the weekday has progressed but we're still in the same week
-          -- AND less than a full week (7 days) has passed since the last check
-        if (actual_date.wday == 1 
-            or (last_check_date.wday ~= 1 and actual_date.wday >= last_check_date.wday)) 
-            and math.floor(diff /(7 * 24 * 60 * 60)) <= 0 then
-          do_reset = false
-        end
+      local last_monday_timestamp = actual_time
+      -- actual_date is not monday
+      if actual_date.wday  ~= 2 then 
+        last_monday_timestamp = actual_time - (((actual_date.wday - 2) % 7) * 86400)
+      end
+      local last_monday = os.date("*t", last_monday_timestamp)
+      last_monday.hour = 0
+      last_monday.min = 0
+      last_monday.sec = 0
+      last_monday_timestamp = os.time(last_monday)
+      if last_monday_timestamp < last_check_epoch then
+        do_reset = false
       end
     end
     if do_reset then

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -447,7 +447,7 @@ function host_pools_nedge.printQuotas(pool_id, host, page_params)
 
 end
 
-function host_pools_nedge.resetPoolsQuotas(pool_filter)
+function host_pools_nedge.resetPoolsQuotas()
   local pools = host_pools_nedge.getPoolsList()
   for _, v in ipairs(pools) do
     local serialized_key = get_pools_serialized_key(tostring(interface.getFirstInterfaceId()), v.id)
@@ -462,11 +462,11 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
   local shapers_config = nf_config:getShapersConfig()
   local quotas_control = shapers_config.quotas_control
   local do_reset = true
-  local last_check_day = ntop.getCache("ntopng.prefs.host_pools.last_check_day")
+  local last_check_day = ntop.getCache("ntopng.prefs.host_pools.last_check_epoch")
 
   local t1 = tonumber(last_check_str) or 0
   if t1 == 0 then
-    ntop.setCache("ntopng.prefs.host_pools.last_check_day", tostring(os.time()))
+    ntop.setCache("ntopng.prefs.host_pools.last_check_epoch", tostring(os.time()))
   else
     local t2 = os.time(os.date())
     local diff = os.difftime(timestamp2, timestamp1)
@@ -488,7 +488,7 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
     end
     if do_reset then
       host_pools_nedge.resetPoolsQuotas()
-      ntop.setCache("ntopng.prefs.host_pools.last_check_day", tostring(os.time()))
+      ntop.setCache("ntopng.prefs.host_pools.last_check_epoch", tostring(os.time()))
     end
   end
 end
@@ -522,7 +522,7 @@ function host_pools_nedge.dailyCheckResetPoolsQuotas()
 
   if do_reset then
     host_pools_nedge.resetPoolsQuotas()
-    ntop.setCache("ntopng.prefs.host_pools.last_check_day", tostring(os.time()))
+    ntop.setCache("ntopng.prefs.host_pools.last_check_epoch", tostring(os.time()))
   end
 end
 

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -465,7 +465,7 @@ function host_pools_nedge.resetPoolsQuotas(pool_filter)
   interface.resetPoolsQuotas(pool_filter)
 end
 
-function host_pools_nedge.lastMondayMidnight(actual_time)
+local function lastMondayMidnight(actual_time)
   local last_monday_timestamp = actual_time
   -- actual_date is not monday
   if actual_date.wday  ~= 2 then 

--- a/scripts/lua/modules/host_pools_nedge.lua
+++ b/scripts/lua/modules/host_pools_nedge.lua
@@ -465,6 +465,20 @@ function host_pools_nedge.resetPoolsQuotas(pool_filter)
   interface.resetPoolsQuotas(pool_filter)
 end
 
+function host_pools_nedge.lastMondayMidnight(actual_time)
+  local last_monday_timestamp = actual_time
+  -- actual_date is not monday
+  if actual_date.wday  ~= 2 then 
+    last_monday_timestamp = actual_time - (((actual_date.wday - 2) % 7) * 86400)
+  end
+  local last_monday = os.date("*t", last_monday_timestamp)
+  last_monday.hour = 0
+  last_monday.min = 0
+  last_monday.sec = 0
+  last_monday_timestamp = os.time(last_monday)
+
+  return last_monday_timestamp
+end
 
 function host_pools_nedge.startupCheckResetPoolsQuotas()
   package.path = dirs.installdir .. "/pro/scripts/lua/nedge/modules/system_config/?.lua;" .. package.path
@@ -493,16 +507,7 @@ function host_pools_nedge.startupCheckResetPoolsQuotas()
         do_reset = false
       end
     elseif quotas_control.reset == "weekly" then
-      local last_monday_timestamp = actual_time
-      -- actual_date is not monday
-      if actual_date.wday  ~= 2 then 
-        last_monday_timestamp = actual_time - (((actual_date.wday - 2) % 7) * 86400)
-      end
-      local last_monday = os.date("*t", last_monday_timestamp)
-      last_monday.hour = 0
-      last_monday.min = 0
-      last_monday.sec = 0
-      last_monday_timestamp = os.time(last_monday)
+      local last_monday_timestamp = lastMondayMidnight(actual_time)
       if last_monday_timestamp < last_check_epoch then
         do_reset = false
       end

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -515,15 +515,15 @@ void HostPools::reloadPools() {
 
     if (_pool_id != 0) {            /* Pool id 0 stats already updated */
       if (stats && stats[_pool_id]) /* Duplicate existing statistics */
-	new_stats[_pool_id] = new (std::nothrow) HostPoolStats(*stats[_pool_id]);
-      else{ /* Brand new statistics */
+	      new_stats[_pool_id] = new (std::nothrow) HostPoolStats(*stats[_pool_id]);
+      else { /* Brand new statistics */
 	      new_stats[_pool_id] = new (std::nothrow) HostPoolStats(iface);
-        #ifdef HAVE_NEDGE
-          snprintf(stats_key, sizeof(stats_key), HOST_POOL_STATS_KEY, iface->get_id(), _pool_id);
-          if (redis->hashGet(stats_key, "stats", json_stats, sizeof(json_stats)) == 0) {
-            new_stats[_pool_id]->deserialize(json_stats,iface);
-          }
-        #endif
+      #ifdef HAVE_NEDGE
+        snprintf(stats_key, sizeof(stats_key), HOST_POOL_STATS_KEY, iface->get_id(), _pool_id);
+        if (redis->hashGet(stats_key, "stats", json_stats, sizeof(json_stats)) == 0) {
+          new_stats[_pool_id]->deserialize(json_stats,iface);
+        }
+      #endif
       }
     }
 

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -92,6 +92,23 @@ void HostPools::deleteStats(HostPoolStats ***hps) {
     }
   }
 }
+/* *************************************** */
+
+void HostPools::storeStats(HostPoolStats **stats) {
+  char stats_key[CONST_MAX_LEN_REDIS_KEY];
+  Redis *redis = ntop->getRedis();
+  
+  for (int i = 0; i < MAX_NUM_HOST_POOLS; i++) {
+    if (stats[i] == nullptr) continue;
+    u_int16_t pool_id = i;
+    snprintf(stats_key, sizeof(stats_key), HOST_POOL_STATS_KEY, iface->get_id(), pool_id);
+
+    std::string json = stats[i]->serialize(iface);
+    if (!json.empty()) {
+      redis->hashSet(stats_key, "stats", json.c_str());
+    }
+  }
+}
 
 /* *************************************** */
 
@@ -104,7 +121,11 @@ HostPools::~HostPools() {
   if (tree_shadow) delete tree_shadow;
   if (tree) delete tree;
 
-  if (stats) deleteStats(&stats);
+  if (stats){ 
+    #ifdef HAVE_NEDGE
+      storeStats(stats);
+    #endif
+    deleteStats(&stats); }
   if (stats_shadow) deleteStats(&stats_shadow);
 
 #ifdef NTOPNG_PRO
@@ -471,7 +492,10 @@ void HostPools::reloadPools() {
     delete [] new_stats;
     return; /* Something went wrong with redis? */
   }
-  
+  #ifdef HAVE_NEDGE
+    char stats_key[CONST_MAX_LEN_REDIS_KEY];
+    char json_stats[CONST_MAX_LEN_REDIS_VALUE];
+  #endif
   for (int i = 0; i < num_pools; i++) {
     if (!pools[i]) continue;
 
@@ -492,8 +516,15 @@ void HostPools::reloadPools() {
     if (_pool_id != 0) {            /* Pool id 0 stats already updated */
       if (stats && stats[_pool_id]) /* Duplicate existing statistics */
 	new_stats[_pool_id] = new (std::nothrow) HostPoolStats(*stats[_pool_id]);
-      else /* Brand new statistics */
-	new_stats[_pool_id] = new (std::nothrow) HostPoolStats(iface);
+      else{ /* Brand new statistics */
+	      new_stats[_pool_id] = new (std::nothrow) HostPoolStats(iface);
+        #ifdef HAVE_NEDGE
+          snprintf(stats_key, sizeof(stats_key), HOST_POOL_STATS_KEY, iface->get_id(), _pool_id);
+          if (redis->hashGet(stats_key, "stats", json_stats, sizeof(json_stats)) == 0) {
+            new_stats[_pool_id]->deserialize(json_stats,iface);
+          }
+        #endif
+      }
     }
 
     reloadPool(_pool_id, new_tree, new_stats);

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -121,9 +121,9 @@ HostPools::~HostPools() {
   if (tree) delete tree;
 
   if (stats){ 
-    #ifdef HAVE_NEDGE
-      storeStats(stats);
-    #endif
+  #ifdef HAVE_NEDGE
+    storeStats(stats);
+  #endif
     deleteStats(&stats); }
   if (stats_shadow) deleteStats(&stats_shadow);
 

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -101,11 +101,10 @@ void HostPools::storeStats(HostPoolStats **stats) {
   for (int i = 0; i < MAX_NUM_HOST_POOLS; i++) {
     if (stats[i] == nullptr) continue;
     u_int16_t pool_id = i;
-    snprintf(stats_key, sizeof(stats_key), HOST_POOL_STATS_KEY, iface->get_id(), pool_id);
-
+    snprintf(stats_key, sizeof(stats_key), HOST_POOL_SERIALIZED_KEY, iface->get_id());
     std::string json = stats[i]->serialize(iface);
     if (!json.empty()) {
-      redis->hashSet(stats_key, "stats", json.c_str());
+      redis->hashSet(stats_key, std::to_string(pool_id).c_str(), json.c_str());
     }
   }
 }
@@ -519,8 +518,8 @@ void HostPools::reloadPools() {
       else { /* Brand new statistics */
 	      new_stats[_pool_id] = new (std::nothrow) HostPoolStats(iface);
       #ifdef HAVE_NEDGE
-        snprintf(stats_key, sizeof(stats_key), HOST_POOL_STATS_KEY, iface->get_id(), _pool_id);
-        if (redis->hashGet(stats_key, "stats", json_stats, sizeof(json_stats)) == 0) {
+        snprintf(stats_key, sizeof(stats_key), HOST_POOL_SERIALIZED_KEY, iface->get_id());
+        if (redis->hashGet(stats_key, std::to_string(_pool_id).c_str(), json_stats, sizeof(json_stats)) == 0) {
           new_stats[_pool_id]->deserialize(json_stats,iface);
         }
       #endif


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues/8882):


Describe changes:
Fixed traffic quota reset after service restart


