### PR TITLE
Removed nprobe ips rule export on host pools page for nEdge

### DIFF
--- a/http_src/vue/page-host-pools.vue
+++ b/http_src/vue/page-host-pools.vue
@@ -18,7 +18,7 @@
                         :title="_i18n('manage_configurations.manage_configuration')"></i> {{
                             _i18n('manage_configurations.manage_configuration') }}
                 </a>
-                <a class="btn btn-primary" download="policy.json" :href="export_policy_url">
+                <a v-if="!isnEdge" class="btn btn-primary" download="policy.json" :href="export_policy_url">
                     <i class="fas fa-file-export" data-bs-toggle="tooltip" data-bs-placement="top"
                         :title="_i18n('manage_configurations.export_policy')"></i> {{
                             _i18n('manage_configurations.export_policy') }}


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:
Removed nprobe ips rule export on host pools page for nEdge

