### PR TITLE
Added 95th percentile to all timeseries charts

### DIFF
--- a/http_src/utilities/graph/dygraph-format.js
+++ b/http_src/utilities/graph/dygraph-format.js
@@ -311,7 +311,7 @@ function formatStandardSerie(timeserie_info, timeserie_options, config, tsCompar
     if (extra_timeseries?.past == true && !disable_past_ts) {
       addNewSerie(past_name, "dash", { color: constant_serie_colors["past"], palette: 1 }, config)
     }
-
+    addNewSerie(perc_name, "point", { color: constant_serie_colors["perc_95"], palette: 1 }, config)
     /* ************************************** */
 
     compactSerie(config, ts_info, extra_timeseries, serie, past_value, scalar, step, epoch_begin, {


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:
Added 95th percentile to all timeseries charts

