### PR TITLE
Update Brew installation command to include json-c

### DIFF
--- a/doc/README.compilation
+++ b/doc/README.compilation
@@ -139,7 +139,7 @@ On MacOS
 
 Using Brew (http://brew.sh):
 
-brew install redis hiredis autoconf automake libtool rrdtool wget pkg-config git son-c libmaxminddb zmq openssl
+brew install redis hiredis autoconf automake libtool rrdtool wget pkg-config git json-c libmaxminddb zmq openssl
 
 Using MacPorts:
 


### PR DESCRIPTION
Fix an accidental delete from a previous commit with the install command with brew https://github.com/ntop/ntopng/commit/3873920bea64232e3ca3694133772de7cb820a91#diff-7bab2413bd2ac01496dfe181a81e713ebd1dbd957ccfa065ec44a2d1ea40e2cdR145

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Describe changes:
in the this [commit](https://github.com/ntop/ntopng/commit/3873920bea64232e3ca3694133772de7cb820a91#diff-7bab2413bd2ac01496dfe181a81e713ebd1dbd957ccfa065ec44a2d1ea40e2cdR145) the brew script removed mysql dependency from the command but it seems like it accidentally change `json-c` to `son-c`.

This PR fix that 

