### PR TITLE
Fix git branch parsing by replacing '/' with '-', sed will fail otherwise

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -45,7 +45,7 @@ if test -d ".git"; then
 GIT_TAG=`git rev-parse HEAD`
 GIT_DATE=`date +%Y%m%d`
 GIT_RELEASE="$GIT_TAG:$GIT_DATE"
-GIT_BRANCH=`git rev-parse --abbrev-ref HEAD | sed "s/heads\///g"`
+GIT_BRANCH=`git rev-parse --abbrev-ref HEAD | sed "s/heads\///g" | tr '/' '-'`
 else
 GIT_RELEASE="$VERSION"
 GIT_DATE=`date`


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)