### PR TITLE
Added sanity checks to the Redis reads/writes exceeded alert

### DIFF
--- a/scripts/lua/modules/check_definitions/system/redis_reads_writes_exceeded.lua
+++ b/scripts/lua/modules/check_definitions/system/redis_reads_writes_exceeded.lua
@@ -1,5 +1,5 @@
 --
--- (C) 2019-24 - ntop.org
+-- (C) 2019-25 - ntop.org
 --
 
 local alert_consts = require("alert_consts")
@@ -7,16 +7,16 @@ local alerts_api = require("alerts_api")
 local alert_categories = require "alert_categories"
 
 local script = {
-  -- Script category
-  category = alert_categories.internals,
-  severity = alert_consts.get_printable_severities().warning,
+   -- Script category
+   category = alert_categories.internals,
+   severity = alert_consts.get_printable_severities().warning,
 
-  hooks = {},
+   hooks = {},
 
-  gui = {
-     i18n_title = "alerts_dashboard.redis_reads_writes_exceeded",
-     i18n_description = "alerts_dashboard.redis_reads_writes_exceeded_descr",
-  }
+   gui = {
+      i18n_title = "alerts_dashboard.redis_reads_writes_exceeded",
+      i18n_description = "alerts_dashboard.redis_reads_writes_exceeded_descr",
+   }
 }
 
 -- #################################################################
@@ -40,6 +40,18 @@ local function check_redis_reads_writes_exceeded(params)
       schema = 'redis:reads_writes_v2'
    }
    local ts = ts_utils.timeseries_query(options)
+   -- Sanity checks
+   if not ts
+      or not ts.series
+      or not ts.series[1]
+      or not ts.series[2]
+      or not ts.series[1].statistics
+      or not ts.series[2].statistics
+      or ts.series[1].statistics.average == nil
+      or ts.series[2].statistics.average == nil
+   then
+      return
+   end
    -- Check if the day target is nan
    if not ts or not (ts.series[1].data[7] == ts.series[1].data[7]) then
       return


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues/9888):


Describe changes:
Added sanity checks to the Redis reads/writes exceeded alert

