### PR TITLE
Removed the mac/device type field from the asset details page when not defined

### DIFF
--- a/scripts/lua/modules/lua_utils_get.lua
+++ b/scripts/lua/modules/lua_utils_get.lua
@@ -572,10 +572,12 @@ function get_symbolic_mac_rev(mac_address)
         return (magic_macs[mac_address])
     else
         local m = string.sub(mac_address, 1, 8)
-        local s = get_mac_classification(m)
-
-        if ((s ~= nil) and (s ~= m)) then
-            return (mac_address .. " [" .. trimSpace(s) .. "]")
+        
+        if not isEmptyString(m) then
+            local s = get_mac_classification(m)
+            if ((s ~= nil) and (s ~= m)) then
+                return (mac_address .. " [" .. trimSpace(s) .. "]")
+            end
         end
     end
 


### PR DESCRIPTION

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)


Describe changes:
Removed the mac/device type field from the asset details page when not defined

