### PR TITLE
Fix InfluxDB top timeseries crash when snmp_utils is unavailable

### DIFF
--- a/scripts/lua/modules/timeseries/drivers/influxdb.lua
+++ b/scripts/lua/modules/timeseries/drivers/influxdb.lua
@@ -1617,7 +1617,7 @@ function driver:timeseries_top(options, top_tags)
             end
 
             local ext_label = nil
-            if options.tags.device then
+            if (ntop.isPro() and options.tags.device) then
                 local snmp_utils = require "snmp_utils"
                 local snmp_cached_dev = require "snmp_cached_dev"
                 local cached_device = snmp_cached_dev:create(options.tags.device)

--- a/scripts/lua/modules/timeseries/drivers/influxdb.lua
+++ b/scripts/lua/modules/timeseries/drivers/influxdb.lua
@@ -1616,17 +1616,19 @@ function driver:timeseries_top(options, top_tags)
                 goto continue
             end
 
-            local snmp_utils = require "snmp_utils"
-            local snmp_cached_dev = require "snmp_cached_dev"
-            local cached_device = snmp_cached_dev:create(options.tags.device)
-            -- In case of flow exporters the data is port, in case of snmp it's if_index
-            local ifindex = query_tag.if_index or query_tag.port
             local ext_label = nil
-            if cached_device then
-                ext_label = snmp_utils.get_snmp_interface_label(cached_device["interfaces"][ifindex])
-            end
-            if isEmptyString(ext_label) then
-                ext_label = ifindex
+            if options.tags.device then
+                local snmp_utils = require "snmp_utils"
+                local snmp_cached_dev = require "snmp_cached_dev"
+                local cached_device = snmp_cached_dev:create(options.tags.device)
+                -- In case of flow exporters the data is port, in case of snmp it's if_index
+                local ifindex = query_tag.if_index or query_tag.port
+                if cached_device then
+                    ext_label = snmp_utils.get_snmp_interface_label(cached_device["interfaces"][ifindex])
+                end
+                if isEmptyString(ext_label) then
+                    ext_label = ifindex
+                end
             end
             -- Special case, top protocol timeseries, here the ext_label needs to be the protocol
             if query_tag.protocol then


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guidelines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):
N/A

Describe changes:

Guard SNMP device lookup behind options.tags.device check in timeseries_top, matching the RRD driver's existing behavior. Previously, snmp_utils was required unconditionally for all top queries, causing a fatal Lua error for non-device schemas like iface:ndpi where no device tag is present.
