### PR TITLE
Fixed the return path of the exporter information graph for historical flows

### DIFF
--- a/scripts/lua/modules/historical_flow_details_formatter.lua
+++ b/scripts/lua/modules/historical_flow_details_formatter.lua
@@ -824,7 +824,7 @@ local function format_historical_flow_additional_exporter(exporters, cli_ip, srv
             -- Insert directed edge
             table.insert(flow_trajectory[exporter_ip], {
                next_hop = next_hop_ip,
-               return_path = false
+               return_path = exp.return_path
             })
             -- Register exporter node label
             nodes_names[exporter_ip] = { firstDottedElement(exporter_name), site }


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)


Describe changes:

Fixed the return path of the exporter information graph for historical flows
