### PR TITLE
Set SNMP v2c as the default version when adding an SNMP device

### DIFF
--- a/http_src/vue/modal-add-snmp-device.vue
+++ b/http_src/vue/modal-add-snmp-device.vue
@@ -236,13 +236,13 @@ const default_snmp_community = props.context.default_snmp_community
 const selected_version = ref(null);
 const snmp_versions = props.context.snmp_v3_available ?
     ref([
-        { id: "0", label: "v1" },
         { id: "1", label: "v2c" },
         { id: "2", label: "v3" },
+        { id: "0", label: "v1" },
     ]) :
     ref([
-        { id: "0", label: "v1" },
-        { id: "1", label: "v2c" }]);
+        { id: "1", label: "v2c" },
+        { id: "0", label: "v1" }]);
 
 const selected_snmp_level = ref(null);
 const snmp_levels = ref([


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)


Describe changes:

Set SNMP v2c as the default version when adding an SNMP device
