### PR TITLE
Added x-api-key header and anthropic version header support

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -129,7 +129,8 @@ class Utils {
 				  char* user_header_token, int connect_timeout, int max_duration_timeout,
 				  bool return_content, bool use_cookie_authentication,
 				  HTTPTranferStats* stats, const char* form_data, char* write_fname,
-				  bool follow_redirects, int ip_version, HttpMethod method);
+				  bool follow_redirects, int ip_version, HttpMethod method,
+				  char* x_api_key = NULL, char* extra_header = NULL);
   static long httpGet(const char* url, const char* username,
                       const char* password, const char* user_header_token,
                       int connect_timeout, int max_duration_timeout,

--- a/src/LuaEngineNtop.cpp
+++ b/src/LuaEngineNtop.cpp
@@ -3252,6 +3252,8 @@ static int ntop_post_http_json_data(lua_State* vm) {
 static int ntop_http_post(lua_State* vm) {
   char *username = (char*)"", *password = (char*)"", *url, *form_data;
   char *bearer = NULL;
+  char *x_api_key = NULL;
+  char *extra_header = NULL;
   int connection_timeout = 30, lifetime_timeout = 0;
   bool return_content = false;
   bool use_cookie_authentication = false;
@@ -3287,10 +3289,17 @@ static int ntop_http_post(lua_State* vm) {
   if (lua_type(vm, 8) == LUA_TSTRING) /* Optional: Authorization: Bearer <token> */
     bearer = (char*)lua_tostring(vm, 8);
 
+  if (lua_type(vm, 9) == LUA_TSTRING) /* Optional: x-api-key header */
+    x_api_key = (char*)lua_tostring(vm, 9);
+
+  if (lua_type(vm, 10) == LUA_TSTRING) /* Optional: raw extra header (e.g. "anthropic-version: 2023-06-01") */
+    extra_header = (char*)lua_tostring(vm, 10);
+
   Utils::httpGetPostPutPatch(vm, url, username, password, bearer,
 			     NULL /* user_header_token */,
       connection_timeout, lifetime_timeout, return_content,
-      use_cookie_authentication, &stats, form_data, NULL, true, 0, method_post);
+      use_cookie_authentication, &stats, form_data, NULL, true, 0, method_post,
+      x_api_key, extra_header);
 
   return (ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_OK));
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -2368,7 +2368,8 @@ bool Utils::httpGetPostPutPatch(lua_State* vm, char* url,
                                 bool use_cookie_authentication,
                                 HTTPTranferStats* stats, const char* form_data,
                                 char* write_fname, bool follow_redirects,
-                                int ip_version, HttpMethod method) {
+                                int ip_version, HttpMethod method,
+                                char* x_api_key, char* extra_header) {
   CURL* curl = curl_easy_init();
   FILE* out_f = NULL;
   bool ret = true;
@@ -2459,6 +2460,15 @@ bool Utils::httpGetPostPutPatch(lua_State* vm, char* url,
       headers = curl_slist_append(headers, tokenBuffer);
       used_tokenBuffer = true;
     }
+
+    if (x_api_key != NULL && x_api_key[0] != '\0') {
+      char x_api_key_header[512];
+      snprintf(x_api_key_header, sizeof(x_api_key_header), "x-api-key: %s", x_api_key);
+      headers = curl_slist_append(headers, x_api_key_header);
+    }
+
+    if (extra_header != NULL && extra_header[0] != '\0')
+      headers = curl_slist_append(headers, extra_header);
 
     if (headers != NULL) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [X] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [X] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [X] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

Added support for extra HTTP post headers, namely anthropic version and x-api-key in addition to bearer. This new header is required by anthropic API
