### PR TITLE
Fixed the timeseries button on the SNMP devices page

### DIFF
--- a/http_src/vue/page-snmp-devices.vue
+++ b/http_src/vue/page-snmp-devices.vue
@@ -431,7 +431,7 @@ function click_button_edit(event) {
 
 function click_button_timeseries(event) {
     const row = event.row;
-    window.location.href = `${linksUtils.getSNMPDetailsPageURL(row.column_ip, http_prefix)}&page=historical`
+    window.location.href = `${linksUtils.getSNMPDetailsPageURL(row.ip, http_prefix)}&page=historical`
 }
 
 /* ************************************** */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues/10273):


Describe changes:
Fixed the timeseries button on the SNMP devices page

