### PR TITLE
Fixed sorting of the seen since column on the MAC addresses page

### DIFF
--- a/http_src/vue/page-macs-list.vue
+++ b/http_src/vue/page-macs-list.vue
@@ -278,7 +278,12 @@ function columns_sorting(col, r0, r1) {
     } else if (col.id == "arp") {
       return sortingFunctions.sortByNumber(r0.arp, r1.arp, col.sort);
     } else if (col.id == "seen_since") {
-      return sortingFunctions.sortByNumber(r0.seen_since, r1.seen_since, col.sort);
+    /** 
+     * R1 and R0 are inverted because we display the distance from seen_since to now rather
+     * than the timestamp. Consequently, in ascending order, the first element will
+     * be the one closest to the current time, which has the highest timestamp.
+     */  
+      return sortingFunctions.sortByNumber(r1.seen_since, r0.seen_since, col.sort);
     } else if (col.id == "throughput") {
       return sortingFunctions.sortByNumber(r0.throughput, r1.throughput, col.sort);
     } else if (col.id == "traffic") {


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)


Describe changes:
Fixed sorting of the seen since column on the MAC addresses page

