### PR TITLE
Removed AS page interface role column when AS mode is not enabled

### DIFF
--- a/http_src/vue/page-as-stats.vue
+++ b/http_src/vue/page-as-stats.vue
@@ -504,6 +504,10 @@ const handleLoadedColumns = (columns) => {
                 && (element.id !== "alerted_flows")
                 && (element.id !== "score"));
         });
+    } else {
+        modified_columns = modified_columns.filter((element) => {
+            return (element.id !== "breakdown_role");
+        });
     }
     return modified_columns;
 };


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues/10427):


Describe changes:
Removed AS page interface role column when AS mode is not enabled

