### PR TITLE
bound buf accesses in mdns reply decoders

### DIFF
--- a/src/MDNS.cpp
+++ b/src/MDNS.cpp
@@ -188,7 +188,8 @@ char* MDNS::decodePTRResponse(char* mdnsbuf, u_int mdnsbuf_len, char* buf,
   *resolved_ip = 0;
 
   /* Skip queries */
-  for (i = 0, idx = 0; (i < to_skip) && (offset < (u_int)mdnsbuf_len);) {
+  for (i = 0, idx = 0;
+       (i < to_skip) && (offset < (u_int)mdnsbuf_len) && (idx < buf_len);) {
     if (queries[offset] != 0) {
       if (queries[offset] < 32)
         buf[idx] = '.';
@@ -217,7 +218,8 @@ char* MDNS::decodePTRResponse(char* mdnsbuf, u_int mdnsbuf_len, char* buf,
   offset += 14;
 
   for (idx = 0;
-       (offset < mdnsbuf_len) && (queries[offset] != '\0') && (idx < buf_len);
+       (offset < mdnsbuf_len) && (queries[offset] != '\0') &&
+       (idx < buf_len - 1);
        offset++, idx++) {
     if (queries[offset] < 32)
       buf[idx] = '.';
@@ -226,7 +228,7 @@ char* MDNS::decodePTRResponse(char* mdnsbuf, u_int mdnsbuf_len, char* buf,
   }
 
   /* As the response ends in ".local" let's cut it */
-  if ((idx > 6) && (strncmp(&buf[idx], ".local", 6) == 0)) idx -= 6;
+  if ((idx > 6) && (strncmp(&buf[idx - 6], ".local", 6) == 0)) idx -= 6;
 
   buf[idx] = '\0';
 
@@ -288,7 +290,9 @@ char* MDNS::decodeAnyResponse(char* mdnsbuf, u_int mdnsbuf_len, char* buf,
     if (qtype == 0x10) {
       int j;
 
-      for (j = 0; (j < len) && (offset < (u_int)mdnsbuf_len); j++) {
+      for (j = 0;
+           (j < len) && (offset < (u_int)mdnsbuf_len) && (idx < buf_len - 1);
+           j++) {
         if (queries[offset + j] < 32) {
           if (idx > 0) buf[idx++] = ';';
         } else


### PR DESCRIPTION
ASan, on a crafted mDNS reply read off the resolver socket:

    WRITE of size 1 ... in MDNS::decodePTRResponse MDNS.cpp:196
    'buf' (128 bytes) <== Memory access overflows this variable

`decodePTRResponse` and `decodeAnyResponse` copy a reply into the 128-byte `buf` owned by `fetchResolveResponses`. Replies are pulled straight off `batch_udp_sock` (reachable via `interface.mdnsReadQueuedResponses`), so both length and contents are attacker controlled.

Before: the query-name loop and the TXT loop advance `idx` with no `buf_len` cap, so a long unterminated name runs past `buf`; the `.local` test compares at `&buf[idx]`, 6 bytes past the terminator; the answer terminator can land on `buf[buf_len]`.

After: each copy stops at `buf_len` (the answer path keeps one byte for the trailing NUL) and the suffix is compared at `&buf[idx - 6]`. The tradeoff is a truncated name on oversized input instead of a stack overwrite.
