### PR TITLE
Fixed missing victim/num_victims/attack params in scan alert message

### DIFF
--- a/scripts/lua/modules/check_definitions/host/scan.lua
+++ b/scripts/lua/modules/check_definitions/host/scan.lua
@@ -72,7 +72,9 @@ local function report_alert(params, attacker, vlan, victim, num_victims, is_vict
    alert:set_score(score)
    alert:set_require_attention()
    if (alert_type_params) and table.len(alert_type_params) > 0 then
-      alert:set_alert_type_params(alert_type_params)
+      if alert_type_params.alert_generation then
+        alert.alert_type_params.alert_generation = alert_type_params.alert_generation
+      end
    end
    alert:set_subtype(host_key)
    alert:set_category(checks.check_categories.security)


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)



Describe changes:
Fixed missing victim/num_victims/attack params in scan alert message

