### PR TITLE
bound mdns name compression pointers in _dissectMDNS

### DIFF
--- a/src/NetworkDiscovery.cpp
+++ b/src/NetworkDiscovery.cpp
@@ -623,14 +623,16 @@ void _dissectMDNS(u_char* buf, u_int buf_len, char* out, u_int out_len) {
           rspbuf[idx] = '.', dissected_ptr = false;
         } else {
           if (buf[offset] == 0xc0) {
-            u_int8_t new_offset = buf[offset + 1];
+            u_int8_t new_offset = (offset + 1 < buf_len) ? buf[offset + 1] : 0;
 
             offset++, dissected_ptr = true;
 
-            while ((idx < (sizeof(rspbuf) - 1)) && (buf[new_offset] != 0)) {
+            while ((idx < (sizeof(rspbuf) - 1)) && (new_offset < buf_len) &&
+                   (buf[new_offset] != 0)) {
               if (buf[new_offset] < 32)
                 rspbuf[idx] = '.';
               else if (buf[new_offset] == 0xc0) {
+                if (new_offset + 1 >= buf_len) break;
                 new_offset = buf[new_offset + 1];
                 continue;
               } else
@@ -668,14 +670,16 @@ void _dissectMDNS(u_char* buf, u_int buf_len, char* out, u_int out_len) {
         rspbuf[idx] = '.', dissected_ptr = false;
       } else {
         if (buf[offset] == 0xc0) {
-          u_int8_t new_offset = buf[offset + 1];
+          u_int8_t new_offset = (offset + 1 < buf_len) ? buf[offset + 1] : 0;
 
           offset++, dissected_ptr = true;
 
-          while ((idx < (sizeof(rspbuf) - 1)) && (buf[new_offset] != 0)) {
+          while ((idx < (sizeof(rspbuf) - 1)) && (new_offset < buf_len) &&
+                 (buf[new_offset] != 0)) {
             if (buf[new_offset] < 32)
               rspbuf[idx] = '.';
             else if (buf[new_offset] == 0xc0) {
+              if (new_offset + 1 >= buf_len) break;
               new_offset = buf[new_offset + 1];
               continue;
             } else
@@ -733,14 +737,16 @@ void _dissectMDNS(u_char* buf, u_int buf_len, char* out, u_int out_len) {
             rspbuf[idx] = '.', dissected_ptr = false;
           } else {
             if (buf[offset] == 0xc0) {
-              u_int8_t new_offset = buf[offset + 1];
+              u_int8_t new_offset = (offset + 1 < buf_len) ? buf[offset + 1] : 0;
 
               offset++, dissected_ptr = true;
 
-              while ((idx < sizeof(rspbuf)) && (buf[new_offset] != 0)) {
+              while ((idx < sizeof(rspbuf)) && (new_offset < buf_len) &&
+                     (buf[new_offset] != 0)) {
                 if (buf[new_offset] < 32)
                   rspbuf[idx] = '.';
                 else if (buf[new_offset] == 0xc0) {
+                  if (new_offset + 1 >= buf_len) break;
                   new_offset = buf[new_offset + 1];
                   continue;
                 } else


### PR DESCRIPTION
- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

ASan, on a crafted mDNS reply pulled off the discovery path:

    heap-buffer-overflow, READ of size 1
    located 185 bytes after a 15-byte region
    #0 _dissectMDNS NetworkDiscovery.cpp:675

Repro: an mDNS answer whose name is a 0xc0 compression pointer inside a reply shorter than the offset the pointer names (a 15 byte reply with byte 13 = 0xc0 and byte 14 = 200 is enough).
Cause: the three name-decode loops in _dissectMDNS follow 0xc0 pointers by reading buf[new_offset], but new_offset is taken straight from the packet and is never bounded against buf_len, so a pointer past the payload walks off buf. Flow::dissectMDNS already guards the same construct with i < payload_len; this dissector did not.
Fix: stop following a pointer once new_offset reaches buf_len, and skip the pointer's second byte when it would land past the end.

Before: an out-of-range pointer read up to ~240 bytes past buf.
After: the name truncates at the packet boundary. The tradeoff is a clipped name on a malformed reply instead of an over-read.