### PR TITLE
bound dns header read to payload length in dissectDNS

### DIFF
--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -6763,7 +6763,7 @@ void Flow::dissectDNS(bool src2dst_direction, char* payload,
   struct ndpi_dns_packet_header dns_header;
   u_int8_t payload_offset = get_protocol() == IPPROTO_UDP ? 0 : 2;
 
-  if (payload_len + payload_offset < sizeof(dns_header)) return;
+  if (payload_len < payload_offset + sizeof(dns_header)) return;
 
   memcpy(&dns_header, &payload[payload_offset], sizeof(dns_header));
 


### PR DESCRIPTION
- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

dissectDNS reads the 12-byte ndpi_dns_packet_header with a memcpy at payload[payload_offset], where payload_offset is 2 for DNS-over-TCP (the RFC1035 length prefix). The length guard is payload_len + payload_offset < sizeof(dns_header), so for TCP it only requires payload_len >= 10, and a 10 to 13 byte segment clears the check while the memcpy still reads 12 bytes from offset 2 and walks up to 4 bytes past the captured payload. It is reached from dissectPacket for any flow nDPI tags as DNS over TCP.

Before, the offset was added to the available length, so the guard passed while the read needed payload_offset + sizeof(dns_header) bytes. After, payload_len has to cover the offset plus the header before the copy runs. The tradeoff is that a too-short DNS-over-TCP segment is skipped instead of over-read; the UDP path (offset 0) keeps the same 12-byte minimum.
