### PR TITLE
Fix incorrect field names in LLM Lua tools

### DIFF
--- a/scripts/lua/modules/llm/tools/get_host_info.lua
+++ b/scripts/lua/modules/llm/tools/get_host_info.lua
@@ -28,7 +28,7 @@ return {
       local out = {
          ip              = info.ip,
          name            = info.name,
-         mac             = info["mac.address"],
+         mac             = info["mac"],
          vlan            = info.vlan,
          bytes_sent      = info["bytes.sent"],
          bytes_rcvd      = info["bytes.rcvd"],

--- a/scripts/lua/modules/llm/tools/get_live_flows_for_host.lua
+++ b/scripts/lua/modules/llm/tools/get_live_flows_for_host.lua
@@ -45,7 +45,7 @@ return {
 					 f["cli.ip"] or "", f["cli.port"] or 0, f["cli.country"] or "",
 					 f["srv.ip"] or "", f["srv.port"] or 0, f["srv.country"] or "",
 					 f["proto.l4"] or "", f["proto.ndpi"] or f["application"] or "",
-					 f["bytes.cli2srv"] or 0, f["bytes.srv2cli"] or 0,
+					 f["cli2srv.bytes"] or 0, f["srv2cli.bytes"] or 0,
 					 f["packets"] or 0, f["duration"] or 0,
 					 (f["flow_score"] or (f.score and f.score.flow_score) or 0),
 					 (f["flow.alerted"] and "yes" or "no"))

--- a/scripts/lua/modules/llm/tools/get_live_flows_summary.lua
+++ b/scripts/lua/modules/llm/tools/get_live_flows_summary.lua
@@ -45,7 +45,7 @@ return {
       local total = { flows = 0, alerted = 0, bytes = 0, score = 0 }
 
       for _, f in ipairs(flows_data.flows) do
-         local bytes      = (f["bytes.cli2srv"] or 0) + (f["bytes.srv2cli"] or 0)
+         local bytes      = (f["cli2srv.bytes"] or 0) + (f["srv2cli.bytes"] or 0)
          local pkts       = f["packets"] or 0
          local score      = f["flow_score"] or (f.score and f.score.flow_score) or 0
          local is_alerted = f["flow.alerted"] and 1 or 0


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

This pull request fixes incorrect field names used by some LLM Lua tools.

Changes

* Fix byte counter field names in get_live_flows_summary.lua.
* Fix byte counter field names in get_live_flows_for_host.lua.
* Fix MAC address field lookup in get_host_info.lua.

These changes restore the correct values returned by the tools for byte counters and MAC addresses.

