### PR TITLE
Add new Lua tools for MCP server

### DIFF
--- a/scripts/lua/modules/llm/tools/discover_lan.lua
+++ b/scripts/lua/modules/llm/tools/discover_lan.lua
@@ -11,13 +11,20 @@ return {
       "IP, hostname, manufacturer, and device type. " ..
       "First attempts an active scan (ARP + mDNS + SSDP); if no results, falls back to the passive " ..
       "MAC table that ntopng builds from observed traffic. " ..
-      "Returns an error if the interface does not support discovery.",
+      "Returns an error if the interface does not support discovery. " ..
+      "Required arguments: ifid (integer) and ifname (string) — interface id and name as provided in the system prompt.",
    handler = function(args)
+      if not args or not args.ifid then
+         return nil, "Missing required argument: ifid"
+      end
+      interface.select(tostring(args.ifid))
+
       if not interface.isDiscoverableInterface() then
          return nil, "This interface does not support network discovery"
       end
 
-      local ifname = interface.getName()
+      local ifname = args.ifname
+      if not ifname then return nil, "Missing required argument: ifname" end
       local devices = {}
 
       -- Run active scan (populates cache, returns status only)
@@ -37,7 +44,7 @@ return {
                   mac          = dev.mac     or "",
                   hostname     = dev.sym     or dev.name or "",
                   manufacturer = mfr,
-                  device_type  = dev.device_type or "",
+                  device_type  = discover.devtype2string(dev.device_type) or "",
                   os           = dev.os_type     or "",
                   source       = "active",
                }

--- a/scripts/lua/modules/llm/tools/discover_lan.lua
+++ b/scripts/lua/modules/llm/tools/discover_lan.lua
@@ -1,0 +1,87 @@
+--
+-- (C) 2013-26 - ntop.org
+--
+
+local json     = require("dkjson")
+local discover = require("discover_utils")
+
+return {
+   name = "discover_lan",
+   description = "Return a table of all devices currently visible on the local network, with MAC address, " ..
+      "IP, hostname, manufacturer, and device type. " ..
+      "First attempts an active scan (ARP + mDNS + SSDP); if no results, falls back to the passive " ..
+      "MAC table that ntopng builds from observed traffic. " ..
+      "Returns an error if the interface does not support discovery.",
+   handler = function(args)
+      if not interface.isDiscoverableInterface() then
+         return nil, "This interface does not support network discovery"
+      end
+
+      local ifname = interface.getName()
+      local devices = {}
+
+      -- Run active scan (populates cache, returns status only)
+      local scan = discover.discover2table(ifname, true)
+      if scan and scan.status and scan.status.code == "OK" then
+         -- Read devices from cache
+         local result = discover.discover2table(ifname, false)
+         if result and result.devices and #result.devices > 0 then
+            for _, dev in ipairs(result.devices) do
+               local mfr = dev.manufacturer or ""
+               if mfr == "" and not isEmptyString(dev.mac) then
+                  local mi = interface.getMacInfo(dev.mac)
+                  if mi then mfr = mi.manufacturer or "" end
+               end
+               devices[#devices + 1] = {
+                  ip           = dev.ip      or "",
+                  mac          = dev.mac     or "",
+                  hostname     = dev.sym     or dev.name or "",
+                  manufacturer = mfr,
+                  device_type  = dev.device_type or "",
+                  os           = dev.os_type     or "",
+                  source       = "active",
+               }
+            end
+         end
+      end
+
+      -- Fallback: passive MAC table
+      if #devices == 0 then
+         local known = interface.getMacsInfo(nil, 999, 0, false, true, nil, nil, nil, nil, nil) or {}
+         local now   = os.time()
+         for _, hmac in pairs(known.macs or {}) do
+            if (hmac["bytes.sent"] or 0) > 0 and (now - (hmac["seen.last"] or 0)) < 300 then
+               local ips = interface.findHostByMac(hmac.mac) or {}
+               local ip  = ""
+               for k, _ in pairs(ips) do ip = k; break end
+               local hostname = ntop.getResolvedName(ip) or ""
+               if hostname == ip then hostname = "" end
+               devices[#devices + 1] = {
+                  ip           = ip,
+                  mac          = hmac.mac          or "",
+                  hostname     = hostname,
+                  manufacturer = hmac.manufacturer  or "",
+                  device_type  = discover.devtype2string(hmac.devtype) or "",
+                  os           = "",
+                  source       = "passive",
+               }
+            end
+         end
+      end
+
+      if #devices == 0 then
+         return "No devices found on the LAN", nil
+      end
+
+      local rows = { "ip,mac,hostname,manufacturer,device_type,os,source" }
+      for _, dev in ipairs(devices) do
+         rows[#rows + 1] = string.format("%s,%s,%s,%s,%s,%s,%s",
+            dev.ip, dev.mac, dev.hostname, dev.manufacturer,
+            dev.device_type, dev.os, dev.source)
+      end
+
+      local hdr = string.format("LAN devices on %s — %d found\n", ifname, #devices)
+      return hdr .. table.concat(rows, "\n"), nil
+   end,
+   opts = { read_only = true }
+}

--- a/scripts/lua/modules/llm/tools/get_interface_addresses.lua
+++ b/scripts/lua/modules/llm/tools/get_interface_addresses.lua
@@ -1,0 +1,35 @@
+--
+-- (C) 2013-26 - ntop.org
+--
+
+local json = require("dkjson")
+
+return {
+   name = "get_interface_addresses",
+   description = "Return the IP addresses assigned to the currently monitored network interface. " ..
+      "Useful to identify the local machine IP without heuristics.",
+   handler = function(args)
+      local ifstats = interface.getStats()
+      if not ifstats then
+         return nil, "Unable to retrieve interface stats"
+      end
+
+      local out = {
+         interface = ifstats.name or interface.getName(),
+         ifid      = ifstats.id,
+         addresses = {},
+      }
+
+      if not isEmptyString(ifstats.ip_addresses) then
+         local tokens = split(ifstats.ip_addresses, ",")
+         for _, addr in pairs(tokens or {}) do
+            if not isEmptyString(addr) then
+               out.addresses[#out.addresses + 1] = addr
+            end
+         end
+      end
+
+      return json.encode(out), nil
+   end,
+   opts = { read_only = true }
+}


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

This pull request adds two new Lua tools for the MCP/LLM integration.

Changes

- Add get_interface_addresses.lua to expose the IP addresses assigned to the currently monitored interface.

- Add discover_lan.lua to enumerate devices on the local network. The tool first performs an active discovery (ARP, mDNS and SSDP) and, if no devices are found, falls back to ntopng’s passive MAC table. The returned information includes IP address, MAC address, hostname, manufacturer, device type, operating system (when available), and discovery source.

These tools extend the MCP interface by providing additional network discovery and interface information to LLM clients.
