### PR TITLE
bound capwap decap reads to caplen in dissectPacket

### DIFF
--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -3417,11 +3417,19 @@ decode_packet_eth:
             */
             u_short eth_type;
             ip_offset = ip_offset + ip_len + sizeof(struct ndpi_udphdr);
+
+            if ((ip_offset + 1) >= h->caplen) {
+              incStats(ingressPacket, h->ts.tv_sec, 0, NDPI_PROTOCOL_UNKNOWN,
+                       NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, 0, len_on_wire, 1,
+                       NULL /* srcMac */, NULL /* dstMac */);
+              goto dissect_packet_end;
+            }
+
             u_int8_t capwap_header_len =
                 ((*(u_int8_t*)&packet[ip_offset + 1]) >> 3) * 4;
             ip_offset = ip_offset + capwap_header_len + 24 + 8;
 
-            if (ip_offset >= h->len) {
+            if (ip_offset >= h->caplen) {
               incStats(ingressPacket, h->ts.tv_sec, 0, NDPI_PROTOCOL_UNKNOWN,
                        NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, 0, len_on_wire, 1,
                        NULL /* srcMac */, NULL /* dstMac */);


### PR DESCRIPTION
The CAPWAP UDP tunnel branch in dissectPacket reads the header-length byte at packet[ip_offset + 1] before checking that byte is inside the captured data, then advances ip_offset by that value and compares the result against h->len. h->len is the on-wire frame size, not h->caplen, so on a snaplen-truncated capture (caplen < len) the header-length read and the later packet[ip_offset - 2] and inner IP reads run past the end of the packet buffer. A crafted CAPWAP-data UDP packet triggers it, and tunnel decoding is on by default.

Before, this branch trusted h->len for the bound while every sibling tunnel case (GRE, ERSPAN, GTP, L2TP, 6in4) bounds against h->caplen. After, the header-length byte is guarded against h->caplen first and the advanced offset is compared to h->caplen as well. The tradeoff is that a CAPWAP frame whose header was clipped by the snap length is now dropped instead of parsed from uncaptured bytes, which is how the other decoders already behave.