### PR TITLE
bound netbios type and name-count reads to buf_len in decodeNetBIOS

### DIFF
--- a/src/MDNS.cpp
+++ b/src/MDNS.cpp
@@ -453,7 +453,7 @@ char* MDNS::decodeNetBIOS(u_char* buf, u_int buf_len, char* out,
   offset = sizeof(struct netbios_header);
   offset += buf[offset] + 2; /* Skip name */
 
-  if (offset > buf_len) return (out);
+  if ((u_int)(offset + 2) > buf_len) return (out);
   i16 = ntohs(*((u_int16_t*)&buf[offset])); /* Type */
   if (i16 != 0x21)                          /* NBSTAT */
     return (out);
@@ -461,7 +461,7 @@ char* MDNS::decodeNetBIOS(u_char* buf, u_int buf_len, char* out,
     offset += 2;
 
   offset += 8; /* Skip class, TTL and data len */
-  if (offset > buf_len) return (out);
+  if ((u_int)(offset + 1) > buf_len) return (out);
 
   if (buf[offset] == 0) /* Number of names */
     return (out);


### PR DESCRIPTION
Repro: a NetBIOS name-service reply (UDP/137) whose name-length byte makes the post-name offset land at the end of the datagram.
Cause: decodeNetBIOS guards the 2-byte type read and the 1-byte name-count read with `offset > buf_len`, which still allows offset == buf_len, and the type read also touches offset+1.
Fix: guard against the actual read width, `(u_int)(offset + 2) > buf_len` and `(u_int)(offset + 1) > buf_len`, matching the `offset + 16` guard already used before the trailing strncpy.

Before: a crafted reply reads 1-2 bytes past buf_len (caught by the --with-sanitizer build).
After: the same reply returns early with an empty name. Well-formed replies behave the same.
