### PR TITLE
clamp product name terminator in readEthernetIPDeviceInfo

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -7899,11 +7899,12 @@ bool Utils::readEthernetIPDeviceInfo(char* device_ip, u_int8_t timeout_sec,
                 offset += 4;
                 lua_push_uint32_table_entry(vm, "serial_number", u32);
 
-                l = response[offset];
+                u_int8_t name_len = response[offset];
+
                 strncpy(str, (char*)&response[offset + 1],
-                        ndpi_min(sizeof(str) - 1, l));
+                        l = ndpi_min(sizeof(str) - 1, name_len));
                 str[l] = '\0';
-                offset += l + 1;
+                offset += name_len + 1;
                 lua_push_str_table_entry(vm, "product_name", str);
 
                 offset++; /* Skip state */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):

Describe changes:

readEthernetIPDeviceInfo parses the List Identity reply an EtherNet/IP device returns over UDP 44818, reachable from Lua through ntop.readEthernetIPDeviceInfo(host). The product name is copied into a 64-byte stack buffer with a clamped strncpy, but the trailing NUL is written at str[l] where l is the raw length byte taken straight from the reply (0..255). A reply that reports a name length of 64 or more writes the terminator up to 191 bytes past str, off the end of the stack frame.

This clamps the index the same way readModbusDeviceInfo already does in this file: l holds the bounded length used for both the copy and str[l], while the raw length stays in name_len so offset still advances over the full field. Well formed replies behave exactly as before; an oversized name is truncated to 63 bytes instead of overwriting the stack.
