### PR TITLE
bound zmq decompress length to buffer size

### DIFF
--- a/src/ZMQCollectorInterface.cpp
+++ b/src/ZMQCollectorInterface.cpp
@@ -531,6 +531,14 @@ void ZMQCollectorInterface::collect_flows() {
               uLen = uncompressed_len =
                   received_uncompressed_size +
                   16; /* We know already the uncompressed size */
+
+              /* zmq_decompress_buf is a fixed MAX_ZMQ_FLOW_BUF+1 byte buffer
+                 and one byte is reserved for the trailing NUL, so the +16 slack
+                 must not make us tell uncompress() the buffer is larger than it
+                 is: with received_uncompressed_size == MAX_ZMQ_FLOW_BUF this
+                 would otherwise write up to 15 bytes past the buffer. */
+              if (uncompressed_len > MAX_ZMQ_FLOW_BUF)
+                uLen = uncompressed_len = MAX_ZMQ_FLOW_BUF;
             }
 
             /* Reuse pre-allocated decompression buffer (MAX_ZMQ_FLOW_BUF+1 bytes) */


### PR DESCRIPTION
Repro: a compressed v4 ZMQ flow message (ZMQ_FLAG_IS_COMPRESSED) whose header sets uncompressed_size to MAX_ZMQ_FLOW_BUF and whose payload inflates a few bytes past the buffer.
Cause: collect_flows now decompresses into the reused fixed buffer zmq_decompress_buf (MAX_ZMQ_FLOW_BUF+1 bytes), but still passes uLen = received_uncompressed_size + 16 to uncompress(), so the length handed to zlib reaches MAX_ZMQ_FLOW_BUF+16 while the buffer is only MAX_ZMQ_FLOW_BUF+1. received_uncompressed_size comes straight from ntohl(h4->uncompressed_size) and is only rejected when it is above MAX_ZMQ_FLOW_BUF.
Fix: cap uLen/uncompressed_len to MAX_ZMQ_FLOW_BUF before the uncompress() call, so zlib is never told the buffer is larger than it is. The old per-message malloc(uncompressed_len+1) absorbed the +16 slack; the fixed preallocated buffer does not.

Before: a crafted message writes up to 15 bytes past zmq_decompress_buf inside uncompress(), and the trailing uncompressed[uLen] terminator writes past the end too (ASAN heap-buffer-overflow).
After: an oversized claim decompresses to Z_BUF_ERROR and the message is dropped; messages that actually fit the buffer behave the same.