### PR TITLE
guard snprintf offset overshoot in snmp handle_async_response

### DIFF
--- a/src/SNMP.cpp
+++ b/src/SNMP.cpp
@@ -108,7 +108,7 @@ void SNMP::handle_async_response(struct snmp_pdu* pdu, const char* agent_ip) {
         int rc = snprintf(&rsp_oid[offset], sizeof(rsp_oid) - offset, "%s%d",
                           (offset > 0) ? "." : "", (int)vp->name_loc[i]);
 
-        if (rc > 0)
+        if ((rc > 0) && (rc < (int)(sizeof(rsp_oid) - offset)))
           offset += rc;
         else
           break;
@@ -234,7 +234,7 @@ void SNMP::handle_async_response(struct snmp_pdu* pdu, const char* agent_ip) {
                             sizeof(response) - rsp_offset, "%s%d",
                             (rsp_offset > 0) ? "." : "", (int)vp->val.objid[i]);
 
-          if (rc > 0)
+          if ((rc > 0) && (rc < (int)(sizeof(response) - rsp_offset)))
             rsp_offset += rc;
           else
             break;


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

handle_async_response builds the dotted OID string (rsp_oid[256]) and the OBJECT IDENTIFIER value (response[128]) by summing snprintf() return values into an offset that also feeds the next call's write pointer and remaining size. snprintf returns the length it would have written, so once a buffer fills the offset walks past its end and the following iteration writes at &buf[offset] while sizeof(buf) - offset wraps to a huge size_t. A response PDU whose OID (name_loc[]/name_length) or OBJECT IDENTIFIER value (val.objid[]/val_len) is long enough overflows the stack buffer, and both fields come straight from the agent through the asynch_response callback.

Before, the loop advanced the offset on any rc > 0. After, it advances only when the write fully fit (rc < remaining), the same test the hex-dump branch a few lines below already uses. Behavior is unchanged for OIDs that fit; an over-length OID now stops at the buffer edge instead of writing past it. The tradeoff is that a pathologically long OID is printed truncated rather than in full, which matches how the sibling string loop already behaves.
