### PR TITLE
bound modbus device-id object loop to response length

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -6536,7 +6536,7 @@ bool Utils::readModbusDeviceInfo(char* device_ip, u_int8_t timeout_sec,
             /* Object id + length must be within the received data, otherwise
                a reply with more objects than bytes walks offset past the
                response buffer */
-            if (offset + 2 > len) break;
+            if ((offset + 2) > len) break;
 
             object_id = response[offset++];
             object_len = response[offset++];

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -6531,8 +6531,15 @@ bool Utils::readModbusDeviceInfo(char* device_ip, u_int8_t timeout_sec,
           char buf[128];
 
           while (num_objects > 0) {
-            u_int8_t object_id = response[offset++];
-            u_int8_t l, object_len = response[offset++];
+            u_int8_t object_id, l, object_len;
+
+            /* Object id + length must be within the received data, otherwise
+               a reply with more objects than bytes walks offset past the
+               response buffer */
+            if (offset + 2 > len) break;
+
+            object_id = response[offset++];
+            object_len = response[offset++];
 
             if ((object_len + offset) < len) {
               switch (object_id) {


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):

Describe changes:

readModbusDeviceInfo reads the Read Device Identification reply a Modbus/TCP device returns, reachable from Lua through ntop.readModbusDeviceInfo(host), into a 512-byte stack buffer. The object loop reads the 2-byte object header with response[offset++] at the top of every iteration but only bounds offset against len when it later copies the value. offset advances by the reply-supplied object_len each pass, so a reply that claims more objects than it carries walks offset past the end of the buffer and the next header read runs off the stack frame.

Break out of the loop when the next object header would fall outside the received bytes. The check sits next to the reads it guards, where offset is known, rather than trusting num_objects taken from the same reply. Well formed replies keep every object within len and behave exactly as before; a truncated or oversized-count reply now stops at the buffer edge instead of reading past it.