### PR TITLE
bound discover ssdp recvfrom to reserve nul terminator

### DIFF
--- a/src/NetworkDiscovery.cpp
+++ b/src/NetworkDiscovery.cpp
@@ -905,8 +905,8 @@ void NetworkDiscovery::discover(lua_State* vm, u_int timeout) {
     struct sockaddr_in from = {0};
     socklen_t s = sizeof(from);
     char ipbuf[32];
-    int len =
-        recvfrom(udp_sock, (char*)msg, sizeof(msg), 0, (sockaddr*)&from, &s);
+    int len = recvfrom(udp_sock, (char*)msg, sizeof(msg) - 1, 0,
+                       (sockaddr*)&from, &s);
 
     if (debug_mode) {
       ntop->getTrace()->traceEvent(


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

`discover()` reads SSDP replies into a 1024-byte stack buffer `msg[]` with `recvfrom(udp_sock, msg, sizeof(msg), ...)` and then terminates the reply with `msg[len] = '\0'`. `recvfrom` fills the whole buffer and reports the truncated length, so a reply of 1024 or more bytes from any host answering the `M-SEARCH` makes `len` equal `sizeof(msg)` and the terminator lands at `msg[1024]`, one byte past the buffer.

Before: the read length was `sizeof(msg)`, so `len` could reach the buffer size and the terminator wrote out of bounds. After: the read is capped at `sizeof(msg) - 1`, matching what `SyslogCollectorInterface::receive` already does, so `len` stays inside the buffer and the terminator is always in range. The tradeoff is one fewer byte of an oversized reply is kept, which was already being dropped since the datagram was truncated at the buffer size.
