### PR TITLE
guard short zoom rtp payload reads in dissectPacket

### DIFF
--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -2665,7 +2665,7 @@ pre_get_flow:
       case NDPI_PROTOCOL_ZOOM:
       case NDPI_PROTOCOL_RTP:
       case NDPI_PROTOCOL_SRTP:
-        if (flow->isZoomRTP()) {
+        if (flow->isZoomRTP() && (trusted_payload_len > 8)) {
           if (payload[0] == 5 /* RTCP/RTP */) {
             u_int8_t encoding_type = payload[8];
 


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):

Describe changes:

The zoom RTP case in dissectPacket reads payload[0] and payload[8] as soon as isZoomRTP() is true, without checking trusted_payload_len the way every sibling case in that switch does. A Zoom-over-RTP flow that receives a UDP datagram shorter than nine payload bytes makes the payload[8] read run past the end of the captured packet.

Gate the branch on trusted_payload_len > 8 before the reads. The encoding-type byte it looks for sits at offset 8, so a packet that could set a stream type is already at least nine bytes and behaves as before; shorter packets fall through instead of reading out of bounds. The check stays at the switch to match the neighboring cases rather than moving the length assumption into the classification path.
