### PR TITLE
bound mdns header read to payload length in dissectMDNS

### DIFF
--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -7078,7 +7078,7 @@ void Flow::dissectMDNS(u_int8_t* payload, u_int16_t payload_len) {
     u_int16_t data_len;
   } PACK_OFF;
 
-  if (((payload[2] & 0x80) != 0x80) || (payload_len < 12))
+  if ((payload_len < 12) || ((payload[2] & 0x80) != 0x80))
     return; /* This is a not MDNS response */
 
   answers = ntohs(*((u_int16_t*)&payload[6])) +


### PR DESCRIPTION
dissectMDNS reads payload[2] in its first guard, but that guard is written ((payload[2] & 0x80) != 0x80) || (payload_len < 12), so the || evaluates the payload[2] read before the length check ever runs. The MDNS case in NetworkInterface::dissectPacket calls flow->dissectMDNS(payload, trusted_payload_len) without the trusted_payload_len > 0 guard its sibling cases (HTTP/SSDP/DNS) use, and for UDP the payload length is l4_len - 8, so a 0 to 2 byte datagram on a flow already classified as MDNS reads past the captured payload.

Swap the two operands so payload_len < 12 short-circuits before the payload[2] read. Before, a short packet dereferences the header first; after, it bails at the length check. Behavior is unchanged for valid responses since both terms must still hold for a 12+ byte packet, and keeping the bound inside the dissector matches the sibling decoders here, which all length-check before touching the header.