### PR TITLE
clamp zmq_recv length in BGPPrefixListener::poll

### DIFF
--- a/src/BGPPrefixListener.cpp
+++ b/src/BGPPrefixListener.cpp
@@ -110,6 +110,12 @@ void BGPPrefixListener::poll() {
       if (bytes_received < 0)
 	break;
 
+      /* zmq_recv() returns the full message size even when the message did
+	 not fit in the buffer, so the copy is truncated at sizeof(buffer)-1
+	 but bytes_received can be larger. Clamp it before terminating. */
+      if (bytes_received > (int)sizeof(buffer) - 1)
+	bytes_received = sizeof(buffer) - 1;
+
       buffer[bytes_received] = '\0';
       message = &buffer[filter_len];
 


### PR DESCRIPTION
BGPPrefixListener::poll copies BGP prefix-change publications into a 1024-byte stack buffer via zmq_recv(sock, buffer, sizeof(buffer)-1, 0). zmq_recv returns the full message size rather than the number of bytes that fit, so a publication over 1023 bytes yields a bytes_received past the buffer end, and buffer[bytes_received] = '\0' then writes off the stack.

Clamp bytes_received to sizeof(buffer)-1 before the terminator, matching the guard collect_flows already uses on its own zmq_recv. Before the change an oversized message terminates out of bounds; after it, the value is capped to what actually landed in the buffer and the trailing bytes are dropped, the same truncation the compressed-flow path accepts.