### PR TITLE
clamp POST Content-Length before narrowing in handle_script_request

### DIFF
--- a/src/LuaEngine.cpp
+++ b/src/LuaEngine.cpp
@@ -1258,9 +1258,21 @@ int LuaEngine::handle_script_request(struct mg_connection* conn,
   /* Check for POST requests */
   if ((strcmp(request_info->request_method, "POST") == 0) &&
       (content_type != NULL)) {
-    u_int32_t content_len = mg_get_content_len(conn) + 1;
+    int64_t submitted_len = mg_get_content_len(conn);
+    u_int32_t content_len;
     bool is_file_upload =
         (strncmp(content_type, "multipart/form-data", 19) == 0) ? true : false;
+
+    /* Content-Length is client supplied and 64 bit wide, so it has to be
+       capped before the narrowing conversion: the size checks below would
+       otherwise run on a wrapped value while mg_read() keeps filling the
+       buffer using the 64 bit one. */
+    if (submitted_len < 0)
+      content_len = 0; /* No Content-Length header */
+    else if (submitted_len > HTTP_MAX_UPLOAD_DATA_LEN)
+      content_len = HTTP_MAX_UPLOAD_DATA_LEN + 1; /* Rejected below */
+    else
+      content_len = (u_int32_t)submitted_len + 1;
 
     if ((!is_file_upload) && (content_len > HTTP_MAX_POST_DATA_LEN)) {
       ntop->getTrace()->traceEvent(TRACE_WARNING,


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

`handle_script_request` narrows the client supplied Content-Length into a `u_int32_t` before any size check, while mongoose keeps that header as the `int64_t` it got from `strtoll()` and never range checks it. Before: a POST with `Content-Length: 4294967299` wraps `content_len` to 4, the 4 MB form limit is compared against the wrapped value and passes, `malloc(4)` succeeds, and `mg_read()` still bounds itself with the untruncated 64 bit `conn->content_len` so it fills all 4 bytes, leaving `post_data[post_data_len] = '\0'` one byte past the allocation. After: the request lands in the existing "too much data" branch. The attacker selects the allocation size by picking Content-Length modulo 2^32, and `LOGIN_URL` is whitelisted, so the POST reaches this before authentication. Compiling the surrounding block together with mongoose's own `mg_read()` under `-fsanitize=address` reports `heap-buffer-overflow WRITE of size 1, 0 bytes after 4-byte region`; the same input is rejected after the change.

The clamp sits where the value is read rather than at the two comparisons, because both limits and the `malloc`/`mg_read` pair consume the same variable and guarding each check individually would leave the allocation path unprotected. Tradeoff: a body declaring more than `HTTP_MAX_UPLOAD_DATA_LEN` now takes the existing oversize branches instead of wrapping, so a client sending a bogus header gets the same rejection an honest oversized upload gets. Content lengths inside the supported range compute an identical `content_len`, and this is the only `mg_get_content_len()` call site in the tree.
