### PR TITLE
hex encode random bytes before mg_md5 in generate_session_id

### DIFF
--- a/src/HTTPserver.cpp
+++ b/src/HTTPserver.cpp
@@ -309,19 +309,25 @@ static int get_secure_random(void *dest, size_t size) {
 static void generate_session_id(char* buf, const char* user,
                                 const char* group) {
   unsigned char random_data[32]; /* 256 bits of entropy */
-  
-  if (get_secure_random(random_data, sizeof(random_data)) != 0) {
+  char random_str[(sizeof(random_data) * 2) + 1];
+
+  if (get_secure_random(random_data, sizeof(random_data)) == 0) {
+    /* mg_md5() expects NUL-terminated strings: hex encode the raw bytes
+       so that no random byte can be read as a terminator */
+    for (u_int i = 0; i < sizeof(random_data); i++)
+      snprintf(&random_str[i * 2], 3, "%02x", random_data[i]);
+  } else {
     NetworkInterface *i = ntop->getInterfaceAtId(0);
     u_int32_t num_pkts;
-    
+
     srand((int)time(0));
 
     num_pkts = (i != NULL) ? i->getNumPackets() : rand();
-    snprintf((char*)random_data, sizeof(random_data), "%d-%u-%s",
+    snprintf(random_str, sizeof(random_str), "%d-%u-%s",
 	     rand(), num_pkts, user);
   }
 
-  mg_md5(buf, (const char*)random_data, user, group, NULL);
+  mg_md5(buf, random_str, user, group, NULL);
 }
 
 /* ****************************************** */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):

None. Found with the clang sanitizer build described in CONTRIBUTING.md.

Describe changes:

`mg_md5()` measures each of its arguments with `strlen()`, and `generate_session_id()` passes it `random_data`, the raw 32 byte block filled by `get_secure_random()`. Before: roughly 88% of logins contain no 0x00 among those bytes, so `strlen()` walks past the stack buffer, which ASAN reports as a stack-buffer-overflow read inside `mg_md5`. The other 12% stop at the first zero byte and hash fewer bits than intended, and when that zero byte comes first, about 1 login in 256, the session id degrades to `md5(user || group)` while the token minted by `create_api_token()` degrades to `md5(user)`, which is `21232f297a57a5a743894a0e4a801fc3` for the default admin account.

After: the block is hex encoded first, so `mg_md5()` receives a real C string and all 256 bits reach the digest. The tradeoff is one extra 65 byte buffer and a doubled hash input versus passing an explicit length, but `mg_md5()` has no length taking variant and adding one would touch every call site in the tree. Keeping the encoding inside `generate_session_id()` leaves `create_session()` and `create_api_token()` unchanged.
