### PR TITLE
clamp 0xC3 lookahead to the string end in purifyHTTPparam

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1385,7 +1385,7 @@ bool Utils::purifyHTTPparam(char* const param, bool strict, bool allowURL,
       char c;
       int new_i;
 
-      if ((u_char)param[i] == 0xC3) {
+      if (((u_char)param[i] == 0xC3) && (param[i + 1] != '\0')) {
         /* Latin-1 within UTF-8 - Align to ASCII encoding */
         c = param[i + 1] | 0x40;
         new_i = i + 1; /* We are actually validating two bytes */


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues): n/a

Describe changes:

Repro: any request parameter whose value ends in `%C3`, for example `/lua/index.lua?ifid=1%C3`.
Cause: the 0xC3 branch consumes two bytes without checking that the second one is not the string terminator; `c` becomes `0x00 | 0x40` = `'@'`, which passes `isPrintableChar`, so `i` lands on the NUL and the loop increment steps past it.
Fix: enter that branch only when `param[i + 1]` is not the terminator.

Before: the scan runs off the end of the buffer. `ntop_http_purify_param` passes a `strdup` copy sized exactly `strlen + 1`, so there is no slack, and the loop keeps replacing every non-printable byte it meets with `'_'` until it happens to hit a zero. ASAN reports a 1-byte read past the region, followed by writes into whatever is next on the heap.

After: the byte is validated on its own. `isPrintableChar` already accepts 192-255, so a lone 0xC3 is kept and well-formed `C3 xx` pairs behave as before. The tradeoff is that a truncated sequence is preserved rather than folded to ASCII, matching how every other unpaired high byte in this loop is treated.

Reached through the default parameter cleanup in `http_lint.lua`, which calls `ntop.httpPurifyParam` with a single argument so `strict` stays false. The `strict=true` call in `LuaEngine.cpp` does not enter this branch, and the other 0xC3 lookahead in `LuaEngine::purifyHTTPParameter` is inside `#ifdef NOT_USED`.
