### PR TITLE
ZMQInterface: safer access to key/value pair

### DIFF
--- a/src/ZMQParserInterface.cpp
+++ b/src/ZMQParserInterface.cpp
@@ -2782,7 +2782,7 @@ u_int8_t ZMQParserInterface::parseJSONCounter(const char* payload,
       const char* key = json_object_iter_peek_name(&it);
       json_object* v = json_object_iter_peek_value(&it);
 
-      if (key != NULL) {
+      if (key != NULL && v != NULL) {
         u_int32_t counter_id;
         size_t key_len = strlen(key);
 
@@ -2841,7 +2841,7 @@ u_int8_t ZMQParserInterface::parseJSONCounter(const char* payload,
           if (parseContainerInfo(v, &stats.container_info))
             stats.container_info_set = true;
         }
-      } /* if key != NULL */
+      }
 
       /* Move to the next element */
       json_object_iter_next(&it);


### PR DESCRIPTION
```
==252==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x5b5afcf2a6b0 bp 0x7fff82006110 sp 0x7fff820058b0 T0)
==252==The signal is caused by a READ memory access.
==252==Hint: address points to the zero page.
    #0 0x5b5afcf2a6b0 in ___interceptor_strcmp /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:500:25
    #1 0x5b5afd27d8ff in ZMQParserInterface::parseJSONCounter(char const*, int) ntopng/src/ZMQParserInterface.cpp:2810:37
    #2 0x5b5afcff8738 in LLVMFuzzerTestOneInput ntopng/fuzz/fuzz_zmq_flow.cpp:214:13
```
Found by oss-fuzz.

