### PR TITLE
bound oid sub-identifier count in snmp read_oid

### DIFF
--- a/third-party/snmp/asn1.c
+++ b/third-party/snmp/asn1.c
@@ -294,7 +294,7 @@ static void *read_oid(void *src, char **oid, int size)
     
   i = 2;
     
-  while (src < endp)
+  while (src < endp && i <= MAX_OID_PARTS)
     {
       src = read_oid_part(src, &parts[i]);
       i++;


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

read_oid in the built-in SNMP client (third-party/snmp/asn1.c, compiled into ntopng and used to parse agent responses when built without net-snmp) decodes an OBJECT IDENTIFIER into a fixed stack array of MAX_OID_PARTS + 1 entries. The decode loop bumps the write index once per sub-identifier and stops only at the end of the OID content, whose length comes from the response. A GetResponse varbind whose OID carries more than 256 sub-identifiers writes past parts[] on the stack with attacker-controlled 64-bit values.

Before, the loop bound is the OID content length alone, so a long OID indexes parts[] beyond its slots. After, the loop also stops at MAX_OID_PARTS, matching the array size and the limit the encoder side already assumes. The tradeoff is that an OID longer than MAX_OID_PARTS is truncated rather than decoded in full, which is the safe behavior for a value that only arrives over the network.
