### PR TITLE
Fix a integer overflow

### DIFF
--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -1967,8 +1967,8 @@ bool NetworkInterface::processPacket(
 
     /* Use the actual h->len and not the h->caplen to determine
        whether a packet is fragmented. */
-    if (ip_len > (int)h->len - ip_offset ||
-        (int)h->len - ip_offset < ip_tot_len ||
+    if ((int)ip_len > h->len - ip_offset ||
+        h->len - ip_offset < (int)ip_tot_len ||
         (iph->frag_off & htons(0x1FFF /* IP_OFFSET */)) ||
         (iph->frag_off & htons(0x2000 /* More Fragments: set */))) {
       is_fragment = true;


### PR DESCRIPTION
```
src/NetworkInterface.cpp:1970:30: runtime error: signed integer overflow: -2147483648 - 4 cannot be represented in type 'int'
    #0 0x579627bf0e78 in NetworkInterface::processPacket(int, unsigned int, int, bool*, timeval const*, unsigned long, ndpi_ethhdr*, unsigned short, ndpi_iphdr*, ndpi_ipv6hdr*, unsigned short, unsigned short, unsigned int, pcap_pkthdr const*, unsigned char const*, unsigned short*, Host**, Host**, Flow**, bool*, unsigned char*) ntopng/src/NetworkInterface.cpp:1970:30
    #1 0x579627bfa6c4 in NetworkInterface::dissectPacket(int, unsigned int, int, bool, unsigned char*, pcap_pkthdr const*, unsigned char const*, unsigned short*, Host**, Host**, Flow**) ntopng/src/NetworkInterface.cpp:3565:26
    #2 0x579627b370cf in LLVMFuzzerTestOneInput ntopng/fuzz/fuzz_dissect_packet.cpp:208:12
```


