### PR TITLE
bound sflow header length to captured datagram bytes

### DIFF
--- a/third-party/sflow_collect.c
+++ b/third-party/sflow_collect.c
@@ -2587,6 +2587,22 @@ static void readFlowSample_header(SFSample *sample)
   sf_log("headerLen %u\n", sample->headerLen);
 
   sample->pkt_header = sample->header = (u_char *)sample->datap; /* just point at the header */
+
+  /* headerLen is taken verbatim from the datagram and is never bounded against
+     the bytes actually captured. It later becomes pcap caplen in
+     handleSflowSample() (the byte count dissectPacket walks from pkt_header) and
+     the read length passed to printHex() below. Clamp it to the bytes present in
+     the received datagram so a forged headerLen cannot drive a read past the
+     recvfrom() buffer. */
+  {
+    u_int32_t avail = ((u_char *)sample->datap <= sample->endp)
+                          ? (u_int32_t)(sample->endp - (u_char *)sample->datap)
+                          : 0;
+
+    if(sample->headerLen > avail)
+      sample->pkt_headerLen = sample->headerLen = avail;
+  }
+
   skipBytes(sample, sample->headerLen);
   {
     char scratch[2000];


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues): n/a

Describe changes:

readFlowSample_header() reads headerLen straight from the sFlow datagram and points pkt_header at the current spot in the 2048-byte recvfrom buffer, but never checks headerLen against the bytes actually captured. That value becomes pcap_pkthdr.caplen in handleSflowSample() (the count of bytes dissectPacket() walks from pkt_header) and the read length passed to printHex() a few lines down. SFABORT is a no-op here, so getData32/skipBytes notice the overrun but never stop. A ~64-byte datagram that claims headerLen 1500 is enough: dissectPacket() only gates on caplen > len, and len (sampledPacketSize) is attacker-set as well, so it walks 1500 bytes from a pointer sitting a dozen bytes into the buffer. ASan reports a heap-buffer-overflow read past the datagram.

Before: caplen and the printHex length came directly off the wire, bounded only by inflating a sibling field. After: headerLen and pkt_headerLen are clamped to endp - datap, the bytes left in the datagram, right where pkt_header is taken, so a forged length is truncated. Valid exporters always place at least headerLen bytes after the field, so their decode stays byte-for-byte identical; only malformed input loses the surplus. The clamp sits in the callee next to the pointer it guards rather than asking dissectPacket() to re-derive a captured length it never sees.
