### PR TITLE
SNMP: fix some memory leaks with v3 devices with authentication

### DIFF
--- a/src/SNMP.cpp
+++ b/src/SNMP.cpp
@@ -574,20 +574,17 @@ bool SNMP::send_snmp_request(char* agent_host, u_int version, char* community,
 
 #ifndef NETSNMP_DISABLE_DES
             if (!strcasecmp(privacy_protocol, "DES")) {
-              snmpSession->session.securityPrivProto = snmp_duplicate_objid(
-                  usmDESPrivProtocol, USM_PRIV_PROTO_DES_LEN);
+              snmpSession->session.securityPrivProto = usmDESPrivProtocol;
               snmpSession->session.securityPrivProtoLen =
                   USM_PRIV_PROTO_DES_LEN;
             } else
 #endif
                 if (!strncasecmp(privacy_protocol, "AES", 3)) {
-              snmpSession->session.securityPrivProto = snmp_duplicate_objid(
-                  usmAESPrivProtocol, USM_PRIV_PROTO_AES_LEN);
+              snmpSession->session.securityPrivProto = usmAESPrivProtocol;
               snmpSession->session.securityPrivProtoLen =
                   USM_PRIV_PROTO_AES_LEN;
             } else if (!strncasecmp(privacy_protocol, "AES128", 6)) {
-              snmpSession->session.securityPrivProto = snmp_duplicate_objid(
-                  usmAESPrivProtocol, USM_PRIV_PROTO_AES128_LEN);
+              snmpSession->session.securityPrivProto = usmAESPrivProtocol;
               snmpSession->session.securityPrivProtoLen =
                   USM_PRIV_PROTO_AES128_LEN;
 #ifdef USM_PRIV_PROTO_AES256_LEN /* Just in case one day it twill be supported \
@@ -598,8 +595,7 @@ bool SNMP::send_snmp_request(char* agent_host, u_int version, char* community,
                                  */
 
             } else if (!strncasecmp(privacy_protocol, "AES256", 6)) {
-              snmpSession->session.securityPrivProto = snmp_duplicate_objid(
-                  usmAESPrivProtocol, USM_PRIV_PROTO_AES256_LEN);
+              snmpSession->session.securityPrivProto = usmAESPrivProtocol;
               snmpSession->session.securityPrivProtoLen =
                   USM_PRIV_PROTO_AES256_LEN;
 #endif
@@ -624,7 +620,7 @@ bool SNMP::send_snmp_request(char* agent_host, u_int version, char* community,
 
       if (username) {
         /* SNMPv3 user name */
-        snmpSession->session.securityName = strdup(username);
+        snmpSession->session.securityName = username;
         snmpSession->session.securityNameLen =
             strlen(snmpSession->session.securityName);
       }


### PR DESCRIPTION
Leaks at every send request.
Note that when we call `snmp_open(&session)`, Net-SNMP internally deep-copies the snmp_session struct into its own internal session object; the library doesn't retain a reference to the original session struct.

```
==153876==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x55977a2470f8 in malloc (/home/nardi/svnrepos/ntopng/ntopng+0xf110f8) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)
    #1 0x7fc6757ba37d in snmp_duplicate_objid (/usr/lib/x86_64-linux-gnu/libnetsnmp.so.40+0x4337d) (BuildId: f47225b3aa835e2f03a3f9e0a06bbddb28560c21)
    #2 0x55977a8f53c6 in SNMP::send_snmp_request(char*, unsigned int, char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:584:56
    #3 0x55977a8f3768 in SNMP::send_snmpv3_request(char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:453:11
    #4 0x55977a8faca2 in SNMP::snmpv3_get_fctn(lua_State*, snmp_pdu_primitive, bool, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:1219:3
    #5 0x55977a8f8faa in SNMP::snmp_get_fctn(lua_State*, snmp_pdu_primitive, bool, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:1237:13
    #6 0x55977a8f9d87 in SNMP::getnext(lua_State*, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:1111:11
    #7 0x55977a5d9884 in ntop_snmpgetnext(lua_State*) /home/nardi/svnrepos/ntopng/src/LuaEngineNtop.cpp:5158:13
    #8 0x55977aed7df5 in luaD_precall (/home/nardi/svnrepos/ntopng/ntopng+0x1ba1df5) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x55977a2470f8 in malloc (/home/nardi/svnrepos/ntopng/ntopng+0xf110f8) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)
    #1 0x7fc6757ba37d in snmp_duplicate_objid (/usr/lib/x86_64-linux-gnu/libnetsnmp.so.40+0x4337d) (BuildId: f47225b3aa835e2f03a3f9e0a06bbddb28560c21)
    #2 0x55977a8f53c6 in SNMP::send_snmp_request(char*, unsigned int, char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:584:56

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x55977a2470f8 in malloc (/home/nardi/svnrepos/ntopng/ntopng+0xf110f8) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)
    #1 0x7fc6757ba37d in snmp_duplicate_objid (/usr/lib/x86_64-linux-gnu/libnetsnmp.so.40+0x4337d) (BuildId: f47225b3aa835e2f03a3f9e0a06bbddb28560c21)
    #2 0x55977a8f53c6 in SNMP::send_snmp_request(char*, unsigned int, char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:584:56

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x55977a22d72e in strdup (/home/nardi/svnrepos/ntopng/ntopng+0xef772e) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)
    #1 0x55977a8f5bb2 in SNMP::send_snmp_request(char*, unsigned int, char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:627:45

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x55977a22d72e in strdup (/home/nardi/svnrepos/ntopng/ntopng+0xef772e) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)
    #1 0x55977a8f5bb2 in SNMP::send_snmp_request(char*, unsigned int, char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:627:45

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x55977a22d72e in strdup (/home/nardi/svnrepos/ntopng/ntopng+0xef772e) (BuildId: 835cdb6c1dbe81c39a90cc11139512d440671a0b)
    #1 0x55977a8f5bb2 in SNMP::send_snmp_request(char*, unsigned int, char*, char*, char*, char*, char*, char*, char*, char*, snmp_pdu_primitive, char**, char*, char**, bool) /home/nardi/svnrepos/ntopng/src/SNMP.cpp:627:45

```


