### PR TITLE
Initial fixes for e2e REST test flakiness

### DIFF
--- a/include/Ntop.h
+++ b/include/Ntop.h
@@ -77,7 +77,10 @@ class Ntop {
   int startupLockFile;
 #endif
   int seed; /* random seed */
-  bool flowChecksReloadInProgress, hostChecksReloadInProgress;
+  /* atomic: written from the HTTP-handler Lua VM thread on reload requests,
+     read from the poller thread (PcapInterface pre-script wait) and cleared
+     from the main thread (checkReloadFlowChecks/checkReloadHostChecks) */
+  std::atomic<bool> flowChecksReloadInProgress, hostChecksReloadInProgress;
   bool hostPoolsReloadInProgress;
   bool interfacesShuttedDown;
   bool offline, forced_offline;
@@ -200,7 +203,7 @@ class Ntop {
 
   /* Hosts Control (e.g., disabled alerts) */
 #ifdef NTOPNG_PRO
-  bool alertExclusionsReloadInProgress;
+  std::atomic<bool> alertExclusionsReloadInProgress;
   AlertExclusions *alert_exclusions, *alert_exclusions_shadow;
   std::map<std::tuple<struct ndpi_in6_addr /* exporter IP */,
                       u_int32_t /* interface_id */>, SNMPInterfaceRole, InterfaceKeyCompare> *ifRoles, *ifRoles_shadow;
@@ -777,6 +780,7 @@ class Ntop {
   }
   void lua_alert_queues_stats(lua_State* vm);
   bool recipients_are_empty();
+  bool waitRecipientsQueuesDrained(u_int max_wait_sec);
   bool recipients_enqueue(AlertFifoItem* notification);
   AlertLevel get_default_recipient_minimum_severity();
   bool recipient_enqueue(u_int16_t recipient_id,
@@ -807,9 +811,18 @@ class Ntop {
 
   inline void reloadFlowChecks() { flowChecksReloadInProgress = true; };
   inline void reloadHostChecks() { hostChecksReloadInProgress = true; };
+  inline bool isFlowChecksReloadPending() { return (flowChecksReloadInProgress); };
+  inline bool isHostChecksReloadPending() { return (hostChecksReloadInProgress); };
   inline void reloadAlertExclusions() {
 #ifdef NTOPNG_PRO
     alertExclusionsReloadInProgress = true;
+#endif
+  };
+  inline bool isAlertExclusionsReloadPending() {
+#ifdef NTOPNG_PRO
+    return (alertExclusionsReloadInProgress);
+#else
+    return (false);
 #endif
   };
   inline void reloadHostPools() { hostPoolsReloadInProgress = true; };

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -1227,6 +1227,36 @@ bool Ntop::recipients_are_empty() { return recipients.empty(); }
 
 /* ******************************************* */
 
+/*
+  Polls recipients_are_empty() until all notification queues are drained
+  (i.e., the recipients.process_notifications 5-second periodic activity has
+  dequeued and dispatched/persisted every pending alert), instead of
+  guessing a fixed delay. Returns true if queues drained before the timeout.
+
+  A single empty read isn't quite enough: an item is removed from its
+  RecipientQueue as soon as Lua dequeues it, slightly before Lua finishes
+  dispatching/persisting it (e.g. the SQLite write in alert_store_db.lua).
+  Requiring two consecutive empty reads closes that small window.
+*/
+bool Ntop::waitRecipientsQueuesDrained(u_int max_wait_sec) {
+  u_int stable_reads = 0;
+  u_int max_iterations = max_wait_sec * 5 /* poll every 200ms */;
+
+  for (u_int i = 0; i < max_iterations; i++) {
+    if (recipients_are_empty()) {
+      if (++stable_reads >= 2) return (true);
+    } else {
+      stable_reads = 0;
+    }
+
+    _usleep(200000);
+  }
+
+  return (false);
+}
+
+/* ******************************************* */
+
 bool Ntop::recipients_enqueue(AlertFifoItem* notification) {
   return recipients.enqueue(notification);
 }
@@ -4323,8 +4353,15 @@ void Ntop::checkShutdownWhenDone() {
       NetworkInterface* iface = getInterface(i);
 
       /* Check all the interfaces reading from pcap files if they are done with
-       * their activities. */
-      if (iface->read_from_pcap_dump() && !iface->read_from_pcap_dump_done())
+       * their activities. NOTE: pcap_dump_processing_done() (not just
+       * read_from_pcap_dump_done()) is required here: packets can be fully
+       * read while flow-end housekeeping (flow_end_housekeeping_walker in
+       * PcapInterface.cpp, which runs the flow-end checks that can still
+       * raise alerts) hasn't run yet. Gating on the earlier flag let the
+       * runtime/post test scripts observe an interface as "done" before its
+       * last flows had actually been checked, silently dropping alerts for
+       * short pcaps. */
+      if (iface->read_from_pcap_dump() && !iface->pcap_dump_processing_done())
         /* iface isn't done yet */
         return;
     }
@@ -4352,12 +4389,18 @@ void Ntop::checkShutdownWhenDone() {
       const char* test_runtime_script_path =
           ntop->getPrefs()->get_test_runtime_script_path();
 
+      /* Wait for pending notifications to be dequeued/dispatched instead of
+         guessing a fixed delay */
+      if (!waitRecipientsQueuesDrained(30 /* sec */))
+       ntop->getTrace()->traceEvent(
+           TRACE_WARNING,
+           "Timed out waiting for pending notifications to drain before "
+           "running the runtime script");
+
       /* Execute as Bash script */
       ntop->getTrace()->traceEvent(TRACE_NORMAL,
                                    "> Running Runtime Script '%s'",
                                    test_runtime_script_path);
-      sleep(10); /* Allow concurrent activities and flushing to complete before
-                    running the test */
       Utils::exec(test_runtime_script_path);
     }
 
@@ -4373,7 +4416,14 @@ void Ntop::checkShutdownWhenDone() {
       const char* test_post_script_path =
           ntop->getPrefs()->get_test_post_script_path();
 
-      sleep(1); /* Give some time to alerts to get dequeued */
+      /* shutdownInterfaces() above flushes all remaining active/idle flows,
+         which can raise further flow-end alerts: wait for those to be
+         dequeued/dispatched too, instead of guessing a fixed delay. */
+      if (!waitRecipientsQueuesDrained(30 /* sec */))
+       ntop->getTrace()->traceEvent(
+           TRACE_WARNING,
+           "Timed out waiting for pending notifications to drain before "
+           "running the post script");
 
       /* Execute as Bash script */
       ntop->getTrace()->traceEvent(TRACE_NORMAL, "> Running Post Script '%s'",

--- a/src/PcapInterface.cpp
+++ b/src/PcapInterface.cpp
@@ -308,8 +308,32 @@ static void* packetPollLoop(void* ptr) {
                                  test_pre_script_path);
     Utils::exec(test_pre_script_path);
 
-    /* Allow check configs to be re-read */
-    sleep(ntop->getPrefs()->get_housekeeping_frequency() * 2);
+    /* If the pre script toggled checks and/or alert exclusions, a hot-reload
+       has been flagged (Ntop::flowChecksReloadInProgress /
+       hostChecksReloadInProgress / alertExclusionsReloadInProgress) but is
+       only applied on the next housekeeping cycle. Poll for its completion
+       instead of guessing a fixed delay: this returns immediately when no
+       reload was requested, and waits exactly as long as needed otherwise. */
+    {
+      u_int max_wait_sec = ntop->getPrefs()->get_housekeeping_frequency() * 6;
+
+      for (u_int waited = 0; waited < max_wait_sec; waited++) {
+       if (!ntop->isFlowChecksReloadPending() &&
+           !ntop->isHostChecksReloadPending() &&
+           !ntop->isAlertExclusionsReloadPending())
+         break;
+
+       sleep(1);
+      }
+
+      if (ntop->isFlowChecksReloadPending() ||
+         ntop->isHostChecksReloadPending() ||
+         ntop->isAlertExclusionsReloadPending())
+       ntop->getTrace()->traceEvent(
+           TRACE_WARNING,
+           "Timed out after %us waiting for checks reload to complete",
+           max_wait_sec);
+    }
 
     ntop->getTrace()->traceEvent(TRACE_NORMAL, "Processing pcap file");
   }


### PR DESCRIPTION
Root causes, found while debugging non-reproducible e2e test failures (tests/e2e/rest):

1. PcapInterface.cpp: the pre-script hot-reload wait used a fixed `sleep(housekeeping_frequency * 2)` after running the pre script, guessing that checks/host-checks/alert-exclusions reload would be applied in time. Replaced with a poll on the actual reload-pending flags (now exposed via `isFlowChecksReloadPending()` / `isHostChecksReloadPending()` / `isAlertExclusionsReloadPending()`), bounded by a generous timeout. Returns immediately when no reload was requested.

2. Ntop.cpp checkShutdownWhenDone(): the runtime/post test scripts were preceded by fixed `sleep()` calls hoping pending alert notifications had been dequeued/dispatched. Replaced with `waitRecipientsQueuesDrained()`, which polls `recipients_are_empty()` (requiring two consecutive empty reads to close the dequeue-vs- persist window) instead of guessing a duration.

3. checkShutdownWhenDone() gated pcap-interface completion on `read_from_pcap_dump_done()` (packets fully read) instead of `pcap_dump_processing_done()` (packets read AND flow-end housekeeping, which runs flow-end checks - fully executed). For pcaps with little other flow activity this let the runtime/post scripts and shutdown proceed before the last flows had actually been checked, silently dropping alerts.

4. Hardened `flowChecksReloadInProgress` / `hostChecksReloadInProgress` / `alertExclusionsReloadInProgress` to `std::atomic<bool>`: they are written from an HTTP-handler Lua VM thread, read from the poller thread, and cleared from the main thread.

There are still some issues with a a few tests, likely depending on runtime script timing.


