### PR TITLE
Fix lost check-reload updates and a day-only date comparison bug

### DIFF
--- a/scripts/lua/modules/format_utils.lua
+++ b/scripts/lua/modules/format_utils.lua
@@ -472,10 +472,10 @@ end
 function format_utils.formatPastEpochShort(input_epoch)
    local epoch_now = os.time()
    local epoch = input_epoch or epoch_now
-   local day = os.date("*t", epoch).day
-   local day_now = os.date("*t", epoch_now).day
+   local d = os.date("*t", epoch)
+   local d_now = os.date("*t", epoch_now)
 
-   if day == day_now then
+   if d.day == d_now.day and d.month == d_now.month and d.year == d_now.year then
       return os.date("%X", epoch)
    end
 

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -4130,7 +4130,18 @@ void Ntop::checkReloadAlertExclusions() {
 void Ntop::checkReloadFlowChecks() {
   if(flowChecksReloadInProgress /* Reload requested from the UI upon configuration changes */) {
     FlowChecksLoader *old,
-        *tmp_flow_checks_loader = new (std::nothrow) FlowChecksLoader();
+        *tmp_flow_checks_loader;
+
+    /* Leave this BEFORE the actual swap and new allocation to guarantee
+       changes are always seen: the reload below (initialize() + the
+       per-interface swap + the sleep(2)) can take a couple of seconds, and
+       if another reload is requested (e.g. by a subsequent REST call) while
+       this one is still in progress, clearing the flag only at the end
+       would silently discard that newer request instead of leaving it
+       pending for the next call. */
+    flowChecksReloadInProgress = false;
+
+    tmp_flow_checks_loader = new (std::nothrow) FlowChecksLoader();
 
     if (!tmp_flow_checks_loader) {
       ntop->getTrace()->traceEvent(
@@ -4153,8 +4164,6 @@ void Ntop::checkReloadFlowChecks() {
 
       delete old;
     }
-
-    flowChecksReloadInProgress = false;
   }
 }
 
@@ -4163,7 +4172,14 @@ void Ntop::checkReloadFlowChecks() {
 void Ntop::checkReloadHostChecks() {
   if(hostChecksReloadInProgress /* Reload requested from the UI upon configuration changes */) {
     HostChecksLoader *old,
-        *tmp_host_checks_loader = new (std::nothrow) HostChecksLoader();
+        *tmp_host_checks_loader;
+
+    /* Leave this BEFORE the actual swap and new allocation to guarantee
+       changes are always seen: see the identical comment in
+       checkReloadFlowChecks() above. */
+    hostChecksReloadInProgress = false;
+
+    tmp_host_checks_loader = new (std::nothrow) HostChecksLoader();
 
     if (!tmp_host_checks_loader) {
       ntop->getTrace()->traceEvent(
@@ -4186,8 +4202,6 @@ void Ntop::checkReloadHostChecks() {
 
       delete old;
     }
-
-    hostChecksReloadInProgress = false;
   }
 }
 


### PR DESCRIPTION
Two further root causes found while stress-testing the previous e2e sync fixes with the full test suite:

1. src/Ntop.cpp: `checkReloadFlowChecks()` and `checkReloadHostChecks()` cleared `flowChecksReloadInProgress` / `hostChecksReloadInProgress` only *after* doing the (multi-second, due to an internal sleep(2)) reload work. Any reload request that arrived while one was already in progress got its flag set, then silently clobbered back to false at the end of the in-flight call - so that newer Redis state (e.g. a check a test had just disabled) was never actually loaded. Fixed to clear the flag *before* doing the reload work, matching the pattern already used (with an explanatory comment) in `checkReloadAlertExclusions()`  and c`heckReloadHostPools()` - those two were already correct.

2. scripts/lua/modules/format_utils.lua: `formatPastEpochShort()` decided whether to show a short (time-only) or full (date+time) timestamp by comparing only the day-of-month against today, not the month/year. Any historical flow whose fixed pcap timestamp happens to fall on the same day-of-month as the current date (e.g. a flow from 25/Dec/2017 compared against today's the 25th of some month) gets its date silently dropped from the alert JSON, producing a genuinely calendar-dependent, non-deterministic test diff. Fixed to compare the full date (day, month, and year).



