### PR TITLE
HTTPserver: fix const X509_NAME for OpenSSL 4.0

### DIFF
--- a/src/HTTPserver.cpp
+++ b/src/HTTPserver.cpp
@@ -522,7 +522,7 @@ static bool ssl_client_x509_auth(
     char* const group, bool* const localuser) {
   bool ret = false;
   X509* cert = NULL;
-  X509_NAME* subj = NULL;
+  const X509_NAME* subj = NULL;
   char subject[256];
   char key[CONST_MAX_LEN_REDIS_KEY];
 
@@ -537,7 +537,7 @@ static bool ssl_client_x509_auth(
           TRACE_INFO, "Client X.509 certificate subject name: '%s'", subject);
 
       if (SSL_get_verify_result(conn->ssl) == X509_V_OK &&
-          X509_NAME_get_text_by_NID(subj, NID_commonName, username,
+          X509_NAME_get_text_by_NID((X509_NAME *)subj, NID_commonName, username,
                                     NTOP_USERNAME_MAXLEN) >= 0) {
         snprintf(key, sizeof(key), CONST_STR_USER_GROUP, username);
 


### PR DESCRIPTION
OpenSSL 4.0 changed X509_get_subject_name() to return const X509_NAME*. Update the local variable to match. This is backward-compatible with older OpenSSL versions since assigning non-const to const is always valid.

Fixes: https://github.com/ntop/ntopng/issues/10829

Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [x] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:


