### PR TITLE
Fix empty blacklist name in blacklisted-flow alert formatting

### DIFF
--- a/scripts/lua/modules/alert_definitions/flow/alert_blacklisted_client_contact.lua
+++ b/scripts/lua/modules/alert_definitions/flow/alert_blacklisted_client_contact.lua
@@ -53,7 +53,9 @@ end
 -- @return A human-readable string
 function alert_blacklisted_client_contact.format(ifid, alert, alert_type_params)
     local blacklist = ""
-    if not isEmptyString(alert_type_params["custom_cat_file"]) then
+    if not isEmptyString(alert_type_params["blacklist"]) then
+        blacklist = alert_type_params["blacklist"]
+    elseif not isEmptyString(alert_type_params["custom_cat_file"]) then
         blacklist = alert_type_params["custom_cat_file"]
     end
     -- The client is blacklisted, so simply use the Client as who description    

--- a/scripts/lua/modules/alert_definitions/flow/alert_blacklisted_server_contact.lua
+++ b/scripts/lua/modules/alert_definitions/flow/alert_blacklisted_server_contact.lua
@@ -38,8 +38,9 @@ end
 -- ##############################################
 
 function alert_blacklisted_server_contact:add_extra_info(alert_json)
-   if alert_json and alert_json.custom_cat_file and not isEmptyString(alert_json.custom_cat_file) then
-        return " [ " .. i18n("flow_details.blacklist", { blacklist = alert_json.custom_cat_file or "" }) .. " ] "
+   local blacklist = alert_json and (alert_json.blacklist or alert_json.custom_cat_file)
+   if not isEmptyString(blacklist) then
+        return " [ " .. i18n("flow_details.blacklist", { blacklist = blacklist }) .. " ] "
     end
     return ""
 end
@@ -53,7 +54,9 @@ end
 -- @return A human-readable string
 function alert_blacklisted_server_contact.format(ifid, alert, alert_type_params)
     local blacklist = ""
-    if not isEmptyString(alert_type_params["custom_cat_file"]) then
+    if not isEmptyString(alert_type_params["blacklist"]) then
+        blacklist = alert_type_params["blacklist"]
+    elseif not isEmptyString(alert_type_params["custom_cat_file"]) then
         blacklist = alert_type_params["custom_cat_file"]
     end
     -- The client is blacklisted, so simply use the Client as who description    

--- a/scripts/lua/modules/historical_flow_utils.lua
+++ b/scripts/lua/modules/historical_flow_utils.lua
@@ -2116,8 +2116,11 @@ function historical_flow_utils.getHistoricalProtocolLabel(record, add_hyperlinks
       local blacklist_name = ""
       if (info.l7cat.label == 'Malware') then
          local json_info = json.decode(info.json)
-         if (json_info and json_info.custom_cat_file) then
-            blacklist_name = " @ " ..json_info.custom_cat_file
+         if json_info then
+            local list = json_info.blacklist or json_info.custom_cat_file
+            if not isEmptyString(list) then
+               blacklist_name = " @ " .. list
+            end
          end
       end
     label = label .. " (" ..historical_flow_utils.get_historical_url(info.l7cat.label, "l7cat", info.l7cat.value, add_hyperlinks) .. blacklist_name .. ")"


### PR DESCRIPTION
Fixes #10835.

`format()` is passed the **top level** of the decoded alert JSON (`alert_utils.getAlertInfo()`
→ `formatAlertMessage()` → `description(ifid, alert, alert_json, ...)`), where the list name is
stored as `blacklist`. It read `custom_cat_file`, which exists only nested under
`alerts["<alert_key>"]`, so the value was always `nil` and every blacklisted-flow alert rendered
as:

```
Blacklisted Server [ Blacklist: "" ]
```

The name was never missing from the data — only from the formatting. Real `flow_alerts.json`
row from the alert store:

```json
{
  "blacklist": "IPsum Threat Intelligence Feed",
  "alerts": { "13": { "custom_cat_file": "IPsum Threat Intelligence Feed", "srv_blacklisted": true } }
}
```

The tree already disagreed with itself: in `alert_blacklisted_client_contact.lua`,
`add_extra_info()` reads `blacklist` while `format()` in the same file read `custom_cat_file`.

## Changes

- `alert_blacklisted_server_contact.lua` — `format()` and `add_extra_info()`
- `alert_blacklisted_client_contact.lua` — `format()`
- `historical_flow_utils.lua` — the same wrong key suppressed the ` @ <list name>` suffix on
  `Malware` category labels in the historical flow view

Each site reads `blacklist` first and keeps `custom_cat_file` as a fallback, so nothing
regresses if that key is populated at the top level elsewhere. `isEmptyString()` is nil-safe
(`ntop_utils.lua`), which the existing call sites already rely on.

Found on 6.6.260811 (Community, FreeBSD/OPNsense); the same code is present on `dev` and
`6.6-stable`.
