### PR TITLE
bound snmp asn1 value length to remaining bytes

### DIFF
--- a/third-party/snmp/asn1.c
+++ b/third-party/snmp/asn1.c
@@ -510,7 +510,18 @@ int asn1_parse_integer_type(ASN1Parser *parser, int *type, int64_t *dest)
     
   size = next_len(parser);
   payload = next_payload(parser);
-    
+
+  /* A declared length must stay within the bytes still present in the current
+     state, otherwise the read loop walks off the datagram. asn1_parse_structure
+     already performs this containment check on its payload. */
+  if ((size < 0) ||
+      ((char*)payload + size >
+       (char*)parser->state->buffer + parser->state->remaining))
+    {
+      if (dest) *dest = 0;
+      return 0;
+    }
+
   for (i = 0; i < size; i++)
     {
       int v;
@@ -555,7 +566,15 @@ int asn1_parse_string_type(ASN1Parser *parser, int *type, char **dest)
     
   size = next_len(parser);
   payload = next_payload(parser);
-    
+
+  if ((size < 0) ||
+      ((char*)payload + size >
+       (char*)parser->state->buffer + parser->state->remaining))
+    {
+      *dest = NULL;
+      return 0;
+    }
+
   *dest = (char*)malloc(size + 1);
     
   for (i = 0; i < size; i++)
@@ -627,9 +646,19 @@ int asn1_parse_oid(ASN1Parser *parser, char **dest)
     return 0;
   size = next_len(parser);
   payload = next_payload(parser);
-    
+
+  /* read_oid dereferences the first payload byte unconditionally, so require at
+     least one content byte and keep the whole OID within the available bytes. */
+  if ((size < 1) ||
+      ((char*)payload + size >
+       (char*)parser->state->buffer + parser->state->remaining))
+    {
+      *dest = NULL;
+      return 0;
+    }
+
   read_oid(payload, dest, size);
-    
+
   consume(parser);
   return 1;
 }


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues): n/a

Describe changes:

The built-in SNMP client parses agent responses with a small ASN.1 reader. asn1_parse_string_type, asn1_parse_integer_type and asn1_parse_oid take the BER content length from next_len() and then read that many bytes off the datagram, but unlike asn1_parse_structure they never check the length against parser->state->remaining. A response whose OCTET STRING, INTEGER or OID declares more bytes than the packet carries makes the read loop run past the buffer. snmp_parse_message reaches asn1_parse_string for the community field before any varbind, so an 8 byte datagram 30 06 02 01 00 04 7F 41 (community length 0x7F, one byte present) is enough. This is the default build path, since HAVE_LIBSNMP is off unless net-snmp is installed.

Before, the three value parsers trusted the wire length; after, each rejects a length that would extend past the remaining bytes, reusing the same containment test asn1_parse_structure already performs. The check sits in the leaf parsers because next_len() cannot see which read follows and the callers above do not know the field width. Valid responses produce identical output; the tradeoff is that a forged or truncated length now aborts that item rather than returning bytes read from adjacent memory.
