### PR TITLE
Fix radius updateLoginInfo early return

### DIFF
--- a/src/Radius.cpp
+++ b/src/Radius.cpp
@@ -357,6 +357,11 @@ bool Radius::updateLoginInfo() {
   ntop->getRedis()->get((char*)PREF_RADIUS_UNPRIV_CAP_GROUP,
                         radiusUnprivCapabilitiesGroup, MAX_RADIUS_LEN);
 
+  if (!strcmp(buf, "chap"))
+    use_chap = true;
+  else
+    use_chap = false;
+
   if ((radiusAuthServer[0] == '\0') || (radiusAcctServer[0] == '\0')) {
     if (radius_debug)
       ntop->getTrace()->traceEvent(
@@ -366,11 +371,6 @@ bool Radius::updateLoginInfo() {
           radiusAuthServer, radiusAcctServer);
     return (false);
   }
-
-  if (!strcmp(buf, "chap"))
-    use_chap = true;
-  else
-    use_chap = false;
 
   if (radius_debug)
     ntop->getTrace()->traceEvent(


### PR DESCRIPTION


Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):


Describe changes:

The Radius::updateLoginInfo checks if any of the auth or acct radius servers are set to empty strings, and if to, returns false. This leads to the "use_chap" variable never being properly set. This can lead to the wrong auth protocol being set if the acct server is not set.

The fix is just to move the auth protocol check before the check for both auth and acct servers.
