### PR TITLE
First batch of `make cppcheck` clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ httpdocs/img/custom_logo.png
 tests/e2e/.auth/
 tests/e2e/results/
 tests/e2e/report/
+
+# cppcheck build cache
+.cppcheck-build/

--- a/Makefile.in
+++ b/Makefile.in
@@ -269,7 +269,8 @@ Makefile: configure Makefile.in
 #	./autogen.sh
 
 cppcheck:
-	cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=all --force -I include/ @HIREDIS_INC@ $(MONGOOSE_INC) $(JSON_INC) $(NDPI_INC) $(LUA_INC) $(CLICKHOUSE_INC) $(LIBRRDTOOL_INC) $(ZEROMQ_INC) src/*.cpp
+	@mkdir -p .cppcheck-build
+	cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=warning,performance,portability --suppress=useInitializationList --suppress=duplInheritedMember --suppress=noCopyConstructor --suppress=noOperatorEq -j $(shell nproc) --cppcheck-build-dir=.cppcheck-build -I include/ @HIREDIS_INC@ $(MONGOOSE_INC) $(JSON_INC) $(NDPI_INC) $(LUA_INC) $(CLICKHOUSE_INC) $(LIBRRDTOOL_INC) $(ZEROMQ_INC) src/*.cpp
 
 test: test_version
 

--- a/include/AggregatedFlowsStats.h
+++ b/include/AggregatedFlowsStats.h
@@ -129,7 +129,7 @@ class AggregatedFlowsStats {
     }
     proto_name = strdup(_proto_name);
   };
-  inline void setInfoKey(string _key) {
+  inline void setInfoKey(const string &_key) {
     if (info_key) {
       free(info_key);
     }

--- a/include/AutonomousSystem.h
+++ b/include/AutonomousSystem.h
@@ -118,7 +118,7 @@ class AutonomousSystem : public GenericHashEntry,
   virtual void updateStats(const struct timeval* tv);
 
   inline char* getSerializationKey(char* buf, u_int bufsize) {
-    snprintf(buf, bufsize, AS_SERIALIZED_KEY, iface->get_id(), asn);
+    snprintf(buf, bufsize, AS_SERIALIZED_KEY, (u_int)iface->get_id(), asn);
     return (buf);
   }
   inline u_int32_t getTotalAlertedNumFlowsAsClient() const {

--- a/include/Bitmap.h
+++ b/include/Bitmap.h
@@ -120,6 +120,8 @@ class Bitmap {
     char* ptr = buf;
     ssize_t remaining = buf_len;
 
+    if (buf_len > 0) buf[0] = '\0';
+
     /* Write hex values in reverse order (most significant first) */
     for (int i = N - 1; i >= 0; i--) {
       int written =
@@ -132,7 +134,8 @@ class Bitmap {
     /* Remove heading zeroes but keep HEX byte-aligned (SQLite doesn't like
      * heading zeroes when inserting blob literals) */
     u_int shifts = 0;
-    for (u_int pos = 0; pos < strlen(buf) - 2; pos += 2) {
+    size_t buf_slen = strlen(buf);
+    for (u_int pos = 0; pos + 2 < buf_slen; pos += 2) {
       u_int8_t cur_byte = 0;
 
       sscanf(&buf[pos], "%02hhX", &cur_byte);

--- a/include/Country.h
+++ b/include/Country.h
@@ -76,7 +76,7 @@ class Country : public GenericHashEntry,
   void lua(lua_State* vm, DetailsLevel details_level, bool asListElement);
 
   inline char* getSerializationKey(char* buf, u_int bufsize) {
-    snprintf(buf, bufsize, COUNTRY_SERIALIZED_KEY, iface->get_id(),
+    snprintf(buf, bufsize, COUNTRY_SERIALIZED_KEY, (u_int)iface->get_id(),
              country_name);
     return (buf);
   }

--- a/include/Flow.h
+++ b/include/Flow.h
@@ -757,7 +757,7 @@ class Flow : public GenericHashEntry {
                     struct timeval* result, bool divide_by_two);
   std::string getFlowInfo(bool isLuaRequest);
   inline std::string getL7JSON() { return (l7_json); }
-  inline void setL7JSON(std::string j) { l7_json = j; }
+  inline void setL7JSON(const std::string &j) { l7_json = j; }
   inline char* getFlowServerInfo() {
     return (isTLS() && protos.tls.client_requested_server_name)
                ? protos.tls.client_requested_server_name

--- a/include/HostAlert.h
+++ b/include/HostAlert.h
@@ -51,11 +51,11 @@ class HostAlert {
   virtual ndpi_serializer* getAlertJSON(ndpi_serializer* serializer) {
     return serializer;
   }
-  void init(HostCheckID _check_id, std::string _check_name, Host* h,
+  void init(HostCheckID _check_id, const std::string &_check_name, Host* h,
             risk_percentage _cli_pctg);
 
  public:
-  HostAlert(HostCheckID check_id, std::string check_name, Host* h,
+  HostAlert(HostCheckID check_id, const std::string &check_name, Host* h,
             risk_percentage _cli_pctg);
   HostAlert(HostCheck* c, Host* h, risk_percentage _cli_pctg);
   virtual ~HostAlert();

--- a/include/NetworkInterface.h
+++ b/include/NetworkInterface.h
@@ -755,7 +755,7 @@ class NetworkInterface : public NetworkInterfaceAlertableEntity {
   void processInterfaceStats(sFlowInterfaceStats* stats);
   void getLiveASNStats(ASNStats* asn_stats, AddressTree* allowed_nets,
                        Paginator* p, lua_State* vm);
-  void getActiveFlowsStats(nDPIStats* stats, FlowStats* status_stats,
+  void getActiveFlowsStats(nDPIStats* ndpi_stats, FlowStats* stats,
                            AddressTree* allowed_nets, Host* h,
                            Host* talking_with_host, Host* client, Host* server,
                            char* flow_info, Paginator* p, lua_State* vm,

--- a/include/Ntop.h
+++ b/include/Ntop.h
@@ -940,8 +940,8 @@ class Ntop {
     updates.sites.store(false, std::memory_order_release);
   }
 
-  bool luaFlowCheckInfo(lua_State* vm, std::string check_name) const;
-  bool luaHostCheckInfo(lua_State* vm, std::string check_name) const;
+  bool luaFlowCheckInfo(lua_State* vm, const std::string &check_name) const;
+  bool luaHostCheckInfo(lua_State* vm, const std::string &check_name) const;
   inline ndpi_risk getUnhandledRisks() const {
     return flow_checks_loader ? flow_checks_loader->getUnhandledRisks() : 0;
   };
@@ -1014,7 +1014,7 @@ class Ntop {
 
   bool createRuntimeInterface(char* name, char* source, int* iface_id);
 
-  void incBlacklisHits(std::string listname);
+  void incBlacklisHits(const std::string &listname);
 #if defined(NTOPNG_PRO) && defined(HAVE_KAFKA)
   inline bool sendKafkaMessage(char* kafka_broker_info, char* msg,
                                u_int msg_len) {
@@ -1048,7 +1048,7 @@ class Ntop {
   static const ndpi_protocol getConstNdpiUnknownProtocol();
 
   std::string getLuaCache(std::string);
-  void setLuaCache(std::string, std::string);  
+  void setLuaCache(const std::string &, const std::string &);
   void dumpLuaCache(lua_State* vm);
 
   bool startPollingBGPPrefixChanges(char *url);

--- a/include/ObservationPoint.h
+++ b/include/ObservationPoint.h
@@ -95,7 +95,7 @@ class ObservationPoint : public GenericHashEntry,
   void lua(lua_State* vm, DetailsLevel details_level, bool asListElement);
 
   inline char* getSerializationKey(char* buf, u_int bufsize) {
-    snprintf(buf, bufsize, OBS_POINT_SERIALIZED_KEY, iface->get_id(),
+    snprintf(buf, bufsize, OBS_POINT_SERIALIZED_KEY, (u_int)iface->get_id(),
              obs_point);
     return (buf);
   }

--- a/include/OtherAlertableEntity.h
+++ b/include/OtherAlertableEntity.h
@@ -62,23 +62,25 @@ class OtherAlertableEntity : public AlertableEntity {
     getAlertCachedValue and setAlertCacheValue as thread safe as they are
     invoked only by periodic scripts and are not accessed by the GUI lua methods
   */
-  inline std::string getAlertCachedValue(std::string key, ScriptPeriodicity p) {
+  inline std::string getAlertCachedValue(const std::string &key,
+                                         ScriptPeriodicity p) {
     std::map<u_int32_t /* std::string */, std::string>::iterator it =
         alert_cache[(u_int)p].find(ndpi_hash_string(key.c_str()));
 
     return ((it != alert_cache[(u_int)p].end()) ? it->second : std::string(""));
   }
 
-  inline void setAlertCacheValue(std::string key, std::string value,
+  inline void setAlertCacheValue(const std::string &key,
+                                 const std::string &value,
                                  ScriptPeriodicity p) {
     alert_cache[(u_int)p][ndpi_hash_string(key.c_str())] = value;
   }
 
-  bool triggerAlert(lua_State* vm, std::string key, ScriptPeriodicity p,
+  bool triggerAlert(lua_State* vm, const std::string &key, ScriptPeriodicity p,
                     time_t now, u_int32_t score, AlertType alert_id,
                     const char* subtype, const char* json, const char* ip,
                     const char* name, u_int16_t port);
-  bool releaseAlert(lua_State* vm, std::string key, ScriptPeriodicity p,
+  bool releaseAlert(lua_State* vm, const std::string &key, ScriptPeriodicity p,
                     time_t now);
 
   void luaAlert(lua_State* vm, const Alert* alert, ScriptPeriodicity p) const;

--- a/include/VLAN.h
+++ b/include/VLAN.h
@@ -65,7 +65,7 @@ class VLAN : public GenericHashEntry,
 
   void lua(lua_State* vm, DetailsLevel details_level, bool asListElement);
   inline char* getSerializationKey(char* buf, u_int bufsize) {
-    snprintf(buf, bufsize, VLAN_SERIALIZED_KEY, iface->get_id(), vlan_id);
+    snprintf(buf, bufsize, VLAN_SERIALIZED_KEY, (u_int)iface->get_id(), vlan_id);
     return (buf);
   }
   inline void setServerPort(bool isTCP, u_int16_t port, ndpi_protocol* proto) {

--- a/include/flow_alerts/CustomFlowLuaScriptAlert.h
+++ b/include/flow_alerts/CustomFlowLuaScriptAlert.h
@@ -44,7 +44,7 @@ class CustomFlowLuaScriptAlert : public FlowAlert {
   ~CustomFlowLuaScriptAlert() {};
 
   FlowAlertType getAlertType() const { return getClassType(); };
-  void setAlertMessage(std::string m) { msg = m; };
+  void setAlertMessage(const std::string &m) { msg = m; };
   bool autoAck() const { return false; };
 };
 

--- a/include/host_alerts/CustomHostLuaScriptAlert.h
+++ b/include/host_alerts/CustomHostLuaScriptAlert.h
@@ -37,11 +37,11 @@ class CustomHostLuaScriptAlert : public HostAlert {
   }
 
   CustomHostLuaScriptAlert(HostCheck* c, Host* f, risk_percentage cli_pctg,
-                           u_int32_t _score, std::string _msg);
+                           u_int32_t _score, const std::string &_msg);
   ~CustomHostLuaScriptAlert() {};
 
   HostAlertType getAlertType() const { return getClassType(); }
-  void setAlertMessage(std::string m) { msg = m; };
+  void setAlertMessage(const std::string &m) { msg = m; };
   void setAlertScore(u_int8_t v) { score = v; };
   virtual u_int8_t getAlertScore() const { return (score); };
 };

--- a/include/host_alerts/ScanRealtimeAlert.h
+++ b/include/host_alerts/ScanRealtimeAlert.h
@@ -46,7 +46,7 @@ class ScanRealtimeAlert : public HostAlert {
   };
 
   ScanRealtimeAlert(HostCheck* c, Host* h, risk_percentage cli_pctg,
-                    std::vector<ScanAlertType> _alerts)
+                    const std::vector<ScanAlertType> &_alerts)
       : HostAlert(c, h, cli_pctg) {
     alerts = _alerts;
   };

--- a/include/host_checks/CustomHostLuaScript.h
+++ b/include/host_checks/CustomHostLuaScript.h
@@ -30,7 +30,7 @@ class CustomHostLuaScript : public HostCheck {
   bool disabled;
 
   HostAlert* allocAlert(HostCheck* c, Host* h, risk_percentage cli_pctg,
-                        u_int32_t _score, std::string _msg) {
+                        u_int32_t _score, const std::string &_msg) {
     CustomHostLuaScriptAlert* alert =
         new CustomHostLuaScriptAlert(c, h, cli_pctg, _score, _msg);
 

--- a/src/BroadcastDomains.cpp
+++ b/src/BroadcastDomains.cpp
@@ -36,7 +36,8 @@ BroadcastDomains::BroadcastDomains(NetworkInterface* _iface) {
   next_update = last_update = 0;
   next_domain_id = 0;
 
-  snprintf(key, sizeof(key), IFACE_BROADCAST_DOMAINS_KEY, iface->get_id());
+  snprintf(key, sizeof(key), IFACE_BROADCAST_DOMAINS_KEY,
+           (u_int)iface->get_id());
   if (ntop->getRedis() && (ntop->getRedis()->get(key, buf, sizeof(buf)) == 0)) {
     broadcast_domains = new (std::nothrow) AddressTree();
 
@@ -60,7 +61,8 @@ BroadcastDomains::~BroadcastDomains() {
 
     ntop->getTrace()->traceEvent(TRACE_INFO, "Broadcast domains: %s", j);
 
-    snprintf(key, sizeof(key), IFACE_BROADCAST_DOMAINS_KEY, iface->get_id());
+    snprintf(key, sizeof(key), IFACE_BROADCAST_DOMAINS_KEY,
+           (u_int)iface->get_id());
     ntop->getRedis()->set(key, j);
   }
 

--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -1106,7 +1106,7 @@ void Flow::processExtraDissectedInformation() {
                 char buf[32];
                 u_int32_t ipv4_addr;
 
-                snprintf(buf, sizeof(buf), "%u.%u.%u.%u", a, b, c, d);
+                snprintf(buf, sizeof(buf), "%d.%d.%d.%d", a, b, c, d);
                 ipv4_addr = ntohl(inet_addr(buf));
 
                 if (addr->equal(ipv4_addr))
@@ -2088,8 +2088,8 @@ char* Flow::print(char* buf, u_int buf_len, bool full_report) {
       ntohs(srv_port), (u_int32_t)first_seen, (u_int32_t)last_seen,
       ndpiDetectedProtocol.proto.master_protocol,
       ndpiDetectedProtocol.proto.app_protocol,
-      get_detected_protocol_name(pbuf, sizeof(pbuf)), get_protocol_category(),
-      get_protocol_category_name(),
+      get_detected_protocol_name(pbuf, sizeof(pbuf)),
+      (u_int)get_protocol_category(), get_protocol_category_name(),
       Utils::intoaV6(getExporterIP(), device_ip_buf, sizeof(device_ip_buf)),
       getInIndex(), getOutIndex(),
       get_packets_cli2srv(), get_packets_srv2cli(),

--- a/src/FlowAlertsLoader.cpp
+++ b/src/FlowAlertsLoader.cpp
@@ -170,8 +170,8 @@ void FlowAlertsLoader::registerRisk(FlowAlertType alert_type,
   if (alert_type.id >= MAX_DEFINED_FLOW_ALERT_TYPE)
     ntop->getTrace()->traceEvent(
         TRACE_ERROR, "Ignoring alert with unknown id %u", alert_type.id);
-
-  alert_to_risk[alert_type.id] = risk;
+  else
+    alert_to_risk[alert_type.id] = risk;
 }
 
 /* **************************************************** */

--- a/src/HTTPserver.cpp
+++ b/src/HTTPserver.cpp
@@ -764,7 +764,7 @@ static int getAuthorizedUser(struct mg_connection* conn,
     return (0);
   }
 
-  snprintf(key, sizeof(key), "%%%u[^|]|%%%u[^|]|%%%u[^|]|%%c",
+  snprintf(key, sizeof(key), "%%%d[^|]|%%%d[^|]|%%%d[^|]|%%c",
            NTOP_USERNAME_MAXLEN - 1, NTOP_GROUP_MAXLEN - 1,
            NTOP_CSRF_TOKEN_LENGTH - 1);
 
@@ -2242,14 +2242,14 @@ HTTPserver::HTTPserver(const char* _docs_dir, const char* _scripts_dir) {
   if (ntop->getPrefs()->get_http_port() == 0) use_http = false;
 
   if (use_http) {
-    snprintf(ports, sizeof(ports), "%s%s%d", http_binding_addr1,
+    snprintf(ports, sizeof(ports), "%s%s%u", http_binding_addr1,
              (http_binding_addr1[0] == '\0') ? "" : ":",
              ntop->getPrefs()->get_http_port());
 
     if (http_binding_addr2[0] &&
         strcmp(http_binding_addr1, http_binding_addr2)) {
       snprintf(&ports[strlen(ports)], sizeof(ports) - strlen(ports) - 1,
-               ",%s:%d", http_binding_addr2, ntop->getPrefs()->get_http_port());
+               ",%s:%u", http_binding_addr2, ntop->getPrefs()->get_http_port());
     }
   }
 
@@ -2260,14 +2260,14 @@ HTTPserver::HTTPserver(const char* _docs_dir, const char* _scripts_dir) {
     addHTTPOption("ssl_certificate", ssl_cert_path);
 
     snprintf(&ports[strlen(ports)], sizeof(ports) - strlen(ports) - 1,
-             "%s%s%s%ds", use_http ? (char*)"," : "", https_binding_addr1,
+             "%s%s%s%us", use_http ? (char*)"," : "", https_binding_addr1,
              (https_binding_addr1[0] == '\0') ? "" : ":",
              ntop->getPrefs()->get_https_port());
 
     if (http_binding_addr2[0] &&
         strcmp(https_binding_addr1, https_binding_addr2)) {
       snprintf(&ports[strlen(ports)], sizeof(ports) - strlen(ports) - 1,
-               ",%s:%d", https_binding_addr2,
+               ",%s:%u", https_binding_addr2,
                ntop->getPrefs()->get_https_port());
     }
   }
@@ -2275,7 +2275,7 @@ HTTPserver::HTTPserver(const char* _docs_dir, const char* _scripts_dir) {
   if ((!use_http) && (!ssl_enabled)) {
     ntop->getTrace()->traceEvent(TRACE_WARNING,
                                  "The HTTP server on the default port");
-    snprintf(ports, sizeof(ports), "%d", ntop->getPrefs()->get_http_port());
+    snprintf(ports, sizeof(ports), "%u", ntop->getPrefs()->get_http_port());
     use_http = true;
   }
 

--- a/src/HostAlert.cpp
+++ b/src/HostAlert.cpp
@@ -23,8 +23,8 @@
 
 /* **************************************************** */
 
-void HostAlert::init(HostCheckID _check_id, std::string _check_name, Host* h,
-                     risk_percentage _cli_pctg) {
+void HostAlert::init(HostCheckID _check_id, const std::string &_check_name,
+                     Host* h, risk_percentage _cli_pctg) {
   host = h;
   expiring = released = false;
   check_id = _check_id;
@@ -40,8 +40,8 @@ void HostAlert::init(HostCheckID _check_id, std::string _check_name, Host* h,
 
 /* **************************************************** */
 
-HostAlert::HostAlert(HostCheckID _check_id, std::string _check_name, Host* h,
-                     risk_percentage _cli_pctg) {
+HostAlert::HostAlert(HostCheckID _check_id, const std::string &_check_name,
+                     Host* h, risk_percentage _cli_pctg) {
   if (trace_new_delete)
     ntop->getTrace()->traceEvent(TRACE_NORMAL, "[new] %s", __FILE__);
   init(_check_id, _check_name, h, _cli_pctg);

--- a/src/HostPools.cpp
+++ b/src/HostPools.cpp
@@ -118,7 +118,7 @@ void HostPools::storeStats(HostPoolStats** stats) {
     if (stats[i] == NULL) continue;
     u_int16_t pool_id = i;
     snprintf(stats_key, sizeof(stats_key), HOST_POOL_SERIALIZED_KEY,
-             iface->get_id());
+             (u_int)iface->get_id());
     std::string json = stats[i]->serialize(iface);
     if (!json.empty()) {
       redis->hashSet(stats_key, std::to_string(pool_id).c_str(), json.c_str());

--- a/src/LocalHost.cpp
+++ b/src/LocalHost.cpp
@@ -90,7 +90,7 @@ void LocalHost::set_hash_entry_state_idle() {
       char key[CONST_MAX_LEN_REDIS_KEY];
       char buf[64], mac_buf[32];
 
-      snprintf(key, sizeof(key), IP_MAC_ASSOCIATION, iface->get_id(),
+      snprintf(key, sizeof(key), IP_MAC_ASSOCIATION, (u_int)iface->get_id(),
                ip.print(buf, sizeof(buf)), vlan_id);
       mac->print(mac_buf, sizeof(mac_buf));
 

--- a/src/LuaEngineInterface.cpp
+++ b/src/LuaEngineInterface.cpp
@@ -1632,6 +1632,8 @@ static int ntop_get_ndpi_full_protocol_name(lua_State* vm) {
   ndpi_protocol proto;
   char buf[64];
 
+  memset(&proto, 0, sizeof(proto));
+
   ntop->getTrace()->traceEvent(TRACE_DEBUG, "%s() called", __FUNCTION__);
 
   if (ntop_lua_check(vm, __FUNCTION__, 1, LUA_TNUMBER) != CONST_LUA_OK)
@@ -5288,7 +5290,7 @@ static int ntop_interface_get_host_tags(lua_State* vm) {
   } else { /* Host offline - lookup on redis */
     char key_buf[CONST_MAX_LEN_REDIS_KEY];
     snprintf(key_buf, sizeof(key_buf), HOST_SERIALIZED_SHORT_KEY,
-             iface->get_id(), host_ip, vlan_id);
+             (u_int)iface->get_id(), host_ip, vlan_id);
     bitmap = iface->getPersistentHostTags(key_buf);
   }
 
@@ -5323,7 +5325,7 @@ static int ntop_interface_get_user_defined_host_tags(lua_State* vm) {
   } else {
     char key_buf[CONST_MAX_LEN_REDIS_KEY];
     snprintf(key_buf, sizeof(key_buf), HOST_SERIALIZED_SHORT_KEY,
-             iface->get_id(), host_ip, vlan_id);
+             (u_int)iface->get_id(), host_ip, vlan_id);
     bitmap = iface->getPersistentHostTags(key_buf) & HOST_USER_TAGS_MASK;
   }
 
@@ -5361,7 +5363,7 @@ static int ntop_interface_set_host_tags(lua_State* vm) {
   } else { /* Host offline - set on redis */
     char key_buf[CONST_MAX_LEN_REDIS_KEY];
     snprintf(key_buf, sizeof(key_buf), HOST_SERIALIZED_SHORT_KEY,
-             iface->get_id(), host_ip, vlan_id);
+             (u_int)iface->get_id(), host_ip, vlan_id);
     iface->setPersistentHostTags(key_buf, bitmap);
   }
 

--- a/src/MacManufacturers.cpp
+++ b/src/MacManufacturers.cpp
@@ -47,7 +47,7 @@ void MacManufacturers::init() {
   struct stat buf;
   FILE* fd;
   char line[256], *cr;
-  int _mac[3];
+  u_int _mac[3];
   u_int32_t mac_key;
 
   if (!(stat(manufacturers_file, &buf) == 0) && (S_ISREG(buf.st_mode)))

--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -754,6 +754,7 @@ int NetworkInterface::addTrustedIssuerDN(const char* dn) {
 ndpi_protocol_category_t NetworkInterface::get_ndpi_proto_category(
     u_int16_t protoid) {
   ndpi_protocol proto;
+  memset(&proto, 0, sizeof(proto));
   protoid = ndpi_map_user_proto_id_to_ndpi_id(get_ndpi_struct(), protoid);
   proto.proto.app_protocol = NDPI_PROTOCOL_UNKNOWN;
   proto.proto.master_protocol = protoid;
@@ -9817,7 +9818,7 @@ void NetworkInterface::FillObsHash() {
     int rc = 0;
 
     snprintf(pattern, sizeof(pattern),
-             "ntopng.serialized_as.ifid_%u_obs_point_*", get_id());
+             "ntopng.serialized_as.ifid_%u_obs_point_*", (u_int)get_id());
 
     // ntop->getTrace()->traceEvent(TRACE_INFO, "Pattern: %s", pattern);
 
@@ -11521,7 +11522,7 @@ void NetworkInterface::reloadDhcpRanges() {
 
   if (!ntop->getRedis()) return;
 
-  snprintf(redis_key, sizeof(redis_key), IFACE_DHCP_RANGE_KEY, get_id());
+  snprintf(redis_key, sizeof(redis_key), IFACE_DHCP_RANGE_KEY, (u_int)get_id());
 
   if ((rsp = (char*)malloc(CONST_MAX_LEN_REDIS_VALUE)) &&
       !ntop->getRedis()->get(redis_key, rsp, CONST_MAX_LEN_REDIS_VALUE) &&
@@ -12636,7 +12637,7 @@ void NetworkInterface::incNumHosts(Host* host, bool rxOnlyHost) {
 
   /* Do not increase nor decrease hosts in case ntopng is shutting down, it's
    * useless */
-  if (isShuttingDown() || (!host->isUnicastHost())) return;
+  if (isShuttingDown()) return;
 
   // ntop->getTrace()->traceEvent(TRACE_NORMAL, "Increasing number of %s %s
   // hosts", local ? "Local" : "Remote", rxOnlyHost ? "RX Only" :
@@ -12672,7 +12673,7 @@ void NetworkInterface::decNumHosts(Host* host, bool rxOnlyHost) {
 
   /* Do not increase nor decrease hosts in case ntopng is shutting down, it's
    * useless */
-  if (isShuttingDown() || (!host->isUnicastHost())) return;
+  if (isShuttingDown()) return;
 
   // ntop->getTrace()->traceEvent(TRACE_NORMAL, "Decreasing number of %s %s
   // hosts", local ? "Local" : "Remote", rxOnlyHost ? "RX Only" :
@@ -13342,6 +13343,7 @@ void NetworkInterface::build_lua_rsp(lua_State* vm,
 
     if (add_app_proto) {
       ndpi_protocol detected_protocol;
+      memset(&detected_protocol, 0, sizeof(detected_protocol));
       char buf[64], proto[16];
       u_int64_t key = flow_stats->getProtoKey();
 
@@ -13504,6 +13506,7 @@ void NetworkInterface::sort_and_filter_flow_stats(
       for (it = stats->count.begin(); it != stats->count.end(); ++it) {
         bool do_add_it = false;
         ndpi_protocol detected_protocol;
+        memset(&detected_protocol, 0, sizeof(detected_protocol));
 
         char buf[64], *proto;
         /* Get from the key, the master and application protocol,
@@ -13599,6 +13602,7 @@ void NetworkInterface::sort_and_filter_flow_stats(
 
       for (it = stats->count.begin(); it != stats->count.end(); ++it) {
         ndpi_protocol detected_protocol;
+        memset(&detected_protocol, 0, sizeof(detected_protocol));
         char buf[64], *proto;
 
         /* Get from the key, the master and application protocol,
@@ -13926,6 +13930,7 @@ void NetworkInterface::lua_push_ports(lua_State* vm, HostsPorts* count,
 
     u_int64_t key = it->first;
     ndpi_protocol detected_protocol;
+    memset(&detected_protocol, 0, sizeof(detected_protocol));
     detected_protocol.proto.master_protocol =
         (u_int16_t)(key & 0x00000000000FFFF);
     detected_protocol.proto.app_protocol =
@@ -14358,6 +14363,7 @@ void NetworkInterface::getVLANFlowsStats(lua_State* vm) {
   for (it = count.begin(); it != count.end(); ++it) {
     AggregatedFlowsStats* fs = it->second;
     ndpi_protocol detected_protocol;
+    memset(&detected_protocol, 0, sizeof(detected_protocol));
     char buf[64], proto[16];
     u_int16_t vlan_id, dst_port;
 

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -5107,7 +5107,7 @@ void Ntop::addLocalNetworkList(const char* rule) {
 
 /* ******************************************* */
 
-bool Ntop::luaFlowCheckInfo(lua_State* vm, std::string check_name) const {
+bool Ntop::luaFlowCheckInfo(lua_State* vm, const std::string &check_name) const {
   FlowChecksLoader* fcl = flow_checks_loader;
   if (fcl) return fcl->luaCheckInfo(vm, check_name);
 
@@ -5116,7 +5116,7 @@ bool Ntop::luaFlowCheckInfo(lua_State* vm, std::string check_name) const {
 
 /* ******************************************* */
 
-bool Ntop::luaHostCheckInfo(lua_State* vm, std::string check_name) const {
+bool Ntop::luaHostCheckInfo(lua_State* vm, const std::string &check_name) const {
   HostChecksLoader* hcl = host_checks_loader;
   if (hcl) return hcl->luaCheckInfo(vm, check_name);
 
@@ -5634,7 +5634,9 @@ bool Ntop::createRuntimeInterface(char* name, char* source, int* iface_id) {
 
 /* ******************************************* */
 
-void Ntop::incBlacklisHits(std::string listname) { blStats.incHits(listname); }
+void Ntop::incBlacklisHits(const std::string &listname) {
+  blStats.incHits(listname);
+}
 
 /* ******************************************* */
 
@@ -5879,7 +5881,7 @@ std::string Ntop::getLuaCache(std::string key) {
 
 /* ******************************************* */
 
-void Ntop::setLuaCache(std::string key, std::string val) {
+void Ntop::setLuaCache(const std::string &key, const std::string &val) {
   luaCacheLock.wrlock(__FILE__, __LINE__);
   luaCache[key] = val;
   luaCacheLock.unlock(__FILE__, __LINE__);

--- a/src/OtherAlertableEntity.cpp
+++ b/src/OtherAlertableEntity.cpp
@@ -66,7 +66,7 @@ void OtherAlertableEntity::luaAlert(lua_State* vm, const Alert* alert,
 /* Return true if the element was inserted, false if already present.
    NOTE: given a ScriptPeriodicity p, only one thread at time can perform
    a triggerAlert. */
-bool OtherAlertableEntity::triggerAlert(lua_State* vm, std::string key,
+bool OtherAlertableEntity::triggerAlert(lua_State* vm, const std::string &key,
                                         ScriptPeriodicity p, time_t now,
                                         u_int32_t score, AlertType alert_id,
                                         const char* subtype, const char* json,
@@ -119,7 +119,7 @@ bool OtherAlertableEntity::triggerAlert(lua_State* vm, std::string key,
 
 /* ****************************************** */
 
-bool OtherAlertableEntity::releaseAlert(lua_State* vm, std::string key,
+bool OtherAlertableEntity::releaseAlert(lua_State* vm, const std::string &key,
                                         ScriptPeriodicity p, time_t now) {
   std::map<u_int32_t /* std::string */, Alert>::iterator it;
   bool rv = false;

--- a/src/ParserInterface.cpp
+++ b/src/ParserInterface.cpp
@@ -73,7 +73,7 @@ ParserInterface::~ParserInterface() {
 /* **************************************************** */
 
 bool ParserInterface::processFlow(ParsedFlow* zflow) {
-  bool src2dst_direction, new_flow;
+  bool src2dst_direction = true, new_flow = false;
   Flow* flow;
   time_t now;
   bool update_seen = false;

--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -635,10 +635,10 @@ void usage() {
 #endif
 	 CONST_DEFAULT_DOCS_DIR, CONST_DEFAULT_SCRIPTS_DIR,
 	 CONST_DEFAULT_CALLBACKS_DIR, CONST_DEFAULT_DATA_DIR,
-	 CONST_DEFAULT_DATA_DIR, CONST_DEFAULT_NTOP_PORT,
-	 CONST_DEFAULT_NTOP_PORT + 1, CONST_DEFAULT_NTOP_USER,
-	 CONST_DEFAULT_TLS_CIPHERS, MAX_NUM_INTERFACE_HOSTS,
-	 MAX_NUM_INTERFACE_HOSTS, CONST_DEFAULT_USERS_FILE);
+	 CONST_DEFAULT_DATA_DIR, (u_int)CONST_DEFAULT_NTOP_PORT,
+	 (u_int)(CONST_DEFAULT_NTOP_PORT + 1), CONST_DEFAULT_NTOP_USER,
+	 CONST_DEFAULT_TLS_CIPHERS, (u_int)MAX_NUM_INTERFACE_HOSTS,
+	 (u_int)MAX_NUM_INTERFACE_HOSTS, CONST_DEFAULT_USERS_FILE);
 
   printf(
 #ifndef WIN32
@@ -719,10 +719,12 @@ void usage() {
 	 "                                    | - clickhouse-user used by clickhouse-client\n"
 	 "                                    | - mysql-user used by the mysql API\n"
 	 "                                    |\n",
-	 CONST_DEFAULT_CLICKHOUSE_TCP_PORT, CONST_DEFAULT_CLICKHOUSE_MYSQL_PORT
+	 (u_int)CONST_DEFAULT_CLICKHOUSE_TCP_PORT,
+	 (u_int)CONST_DEFAULT_CLICKHOUSE_MYSQL_PORT
 #ifndef HAVE_NEDGE
 	 ,
-	 CONST_DEFAULT_CLICKHOUSE_TCP_PORT, CONST_DEFAULT_CLICKHOUSE_MYSQL_PORT
+	 (u_int)CONST_DEFAULT_CLICKHOUSE_TCP_PORT,
+	 (u_int)CONST_DEFAULT_CLICKHOUSE_MYSQL_PORT
 #endif
 	 );
 #endif
@@ -757,7 +759,8 @@ void usage() {
 	 "[--dump-queue-block-size] <size>    | Set the in-memory ClickHouse data block size (Default: %u)\n"
 	 "[--direct-flows-dump]               | Dump collected flows directly before any additional processing\n"
 	 "[--readonly-flows-dump]             | Keep ClickHouse connected for reading but disable flow dump (writing)\n",
-	 CLICKHOUSE_MAX_DUMP_BLOCKS, CLICKHOUSE_MAX_DUMP_ROWS_PER_BLOCK);
+	 (u_int)CLICKHOUSE_MAX_DUMP_BLOCKS,
+	 (u_int)CLICKHOUSE_MAX_DUMP_ROWS_PER_BLOCK);
 #endif
   printf(
 	 "[--hw-timestamp-mode] <mode>        | Enable hw "

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -117,7 +117,7 @@ int StatsManager::deleteStatsOlderThan(const char* cache_name,
 
   snprintf(query, sizeof(query),
            "DELETE FROM %s WHERE "
-           "CAST(TSTAMP AS INTEGER) < %lu",
+           "CAST(TSTAMP AS INTEGER) < %ld",
            cache_name, static_cast<long int>(key));
 
   m.lock(__FILE__, __LINE__);
@@ -249,8 +249,8 @@ int StatsManager::retrieveStatsInterval(struct statsManagerRetrieval* retvals,
   *retvals = empty;
 
   snprintf(query, sizeof(query),
-           "SELECT STATS FROM %s WHERE TSTAMP >= %lu "
-           "AND TSTAMP <= %lu",
+           "SELECT STATS FROM %s WHERE TSTAMP >= %ld "
+           "AND TSTAMP <= %ld",
            cache_name, static_cast<long int>(key_start),
            static_cast<long int>(key_end));
 
@@ -500,8 +500,8 @@ int StatsManager::getSampling(string* sampling, const char* cache_name,
 
   snprintf(query, sizeof(query),
            "SELECT STATS FROM %s WHERE "
-           "CAST(TSTAMP AS INTEGER) <= %lu AND "
-           "CAST(TSTAMP AS INTEGER) >= %lu",
+           "CAST(TSTAMP AS INTEGER) <= %ld AND "
+           "CAST(TSTAMP AS INTEGER) >= %ld",
            cache_name, static_cast<long int>(key_high),
            static_cast<long int>(key_low));
 

--- a/src/SyslogParserInterface.cpp
+++ b/src/SyslogParserInterface.cpp
@@ -350,7 +350,7 @@ void SyslogParserInterface::doProducersMappingUpdate() {
 
   producers_map.clear();
 
-  snprintf(key, sizeof(key), SYSLOG_PRODUCERS_MAP_KEY, get_id());
+  snprintf(key, sizeof(key), SYSLOG_PRODUCERS_MAP_KEY, (u_int)get_id());
 
   rc = ntop->getRedis()->hashGetAll(key, &keys, &values);
 

--- a/src/Trace.cpp
+++ b/src/Trace.cpp
@@ -57,8 +57,8 @@ void Trace::rotate_logs(bool forceRotation) {
   logFd = NULL;
 
   for (int i = MAX_NUM_NTOPNG_LOG_FILES - 1; i >= 1; i--) {
-    snprintf(buf1, sizeof(buf1), "%s.%u", logFile, i);
-    snprintf(buf2, sizeof(buf2), "%s.%u", logFile, i + 1);
+    snprintf(buf1, sizeof(buf1), "%s.%d", logFile, i);
+    snprintf(buf2, sizeof(buf2), "%s.%d", logFile, i + 1);
 
     if (Utils::file_exists(buf1)) rename(buf1, buf2);
   } /* for */

--- a/src/host_alerts/CustomHostLuaScriptAlert.cpp
+++ b/src/host_alerts/CustomHostLuaScriptAlert.cpp
@@ -26,7 +26,7 @@
 CustomHostLuaScriptAlert::CustomHostLuaScriptAlert(HostCheck* c, Host* h,
                                                    risk_percentage cli_pctg,
                                                    u_int32_t _score,
-                                                   std::string _msg)
+                                                   const std::string &_msg)
     : HostAlert(c, h, cli_pctg) {
   score = _score, msg = _msg;
 };


### PR DESCRIPTION
Rework the `cppcheck:` recipe so it is usable in practice:
  - `--enable=all` -> `--enable=warning,performance,portability` (drops the `style`/`information`/`unusedFunction` groups, which produced hundreds of opinion-level hits)
  - drop `--force` (was re-analyzing every file once per #ifdef combination; single files took 40+ min). Analyzes the default build config only.
  - add `-j $(shell nproc)` + `--cppcheck-build-dir=.cppcheck-build` for parallelism and incremental caching; `mkdir -p` the cache dir in the recipe
  - suppress checks that are noise for this codebase:
      * useInitializationList  - micro perf, POD members
      * duplInheritedMember    - intentional non-virtual name shadowing
        (operator[], swap, enqueue, incUses, lua, ...)
      * noCopyConstructor / noOperatorEq - the flagged classes
        (NetworkInterface, Ntop, Flow, ...) are non-copyable by design and
        always held by pointer; the fix cppcheck suggests (add operator=)
        is meaningless for them
  - .gitignore: ignore the new .cppcheck-build/ cache directory

FlowAlertsLoader::registerRisk (src/FlowAlertsLoader.cpp)
  Missing `else`: `alert_to_risk[alert_type.id] = risk` was executed even when
  `alert_type.id >= MAX_DEFINED_FLOW_ALERT_TYPE` -> out-of-bounds array write.
  The sibling registerAlert() already had the `else`.

Uninitialized ndpi_protocol structs (src/NetworkInterface.cpp x6, src/LuaEngineInterface.cpp x1)
  Local `ndpi_protocol` values were only partially initialized (proto.* set,
  but breed/fpc/state/category/custom_category_userdata left indeterminate)
  and then passed by value to get_ndpi_full_proto_name() /
  get_ndpi_proto_category(). Added `memset(&x, 0, sizeof(x))` at each
  declaration, matching the existing convention elsewhere in the tree.

Uninitialized locals
  - src/ParserInterface.cpp: `src2dst_direction` was read on the `flow == NULL` path (getFlow() not called). Initialize to a defined value; the value is not otherwise observable on that path.
  - include/Bitmap.h (toHexString): if `buf_len <= 0` the first loop never runs and `strlen(buf)` reads uninitialized memory; also `strlen(buf) - 2` underflows (unsigned) when the string is shorter than 2 bytes. Null- terminate up front and hoist strlen into a `size_t`, iterate with `pos + 2 < len`.

src/NetworkInterface.cpp incNumHosts()/decNumHosts()
  `if (isShuttingDown() || (!host->isUnicastHost())) return;` - the second
  term is always false, the function already returned on `!isUnicastHost()`
  a few lines above. Dropped it.

include/NetworkInterface.h getActiveFlowsStats()
  Declaration and definition disagreed on the first two parameter *names*
  (`stats, status_stats` vs `ndpi_stats, stats`); types matched. Renamed the
  header params to match the implementation.

No behavioural change; each argument was already non-negative.

  - Interface id (`get_id()` returns int; kept int because 3 call sites test `== -1`) formatted with %u in redis-key macros -> cast the argument `(u_int)` at the call site: include/AutonomousSystem.h, include/Country.h, include/ObservationPoint.h, include/VLAN.h, src/BroadcastDomains.cpp (x2), src/HostPools.cpp, src/LocalHost.cpp, src/LuaEngineInterface.cpp (x3), src/NetworkInterface.cpp (x2), src/SyslogParserInterface.cpp
  - src/HTTPserver.cpp: `%d` with get_http_port()/get_https_port() (u_int) -> `%u`; the scanf-width builder `"%%%u[^|]..."` fed `int` macros -> `%d`
  - src/Flow.cpp: `"%u.%u.%u.%u"` with `int` octets from a `%d` sscanf -> `%d`; `%u` (arg 13) with get_protocol_category() enum -> cast `(u_int)`
  - src/MacManufacturers.cpp: `int _mac[3]` scanned with `%02x` (wants `unsigned int*`) -> declare `u_int _mac[3]`
  - src/StatsManager.cpp: `%lu` with `static_cast<long int>(key)` epoch values -> `%ld` (respects the explicit signed cast)
  - src/Trace.cpp: `"%s.%u"` with loop `int i` / `i + 1` -> `%d`
  - src/Prefs.cpp: `%u` in usage() help text fed CONST_DEFAULT_* / MAX_NUM_* / CLICKHOUSE_MAX_* int macros -> cast `(u_int)`

std::string / std::vector parameters taken by value, changed to `const &` (declaration and definition kept in sync; none are virtual or overrides, so callers are source-compatible):

  - AggregatedFlowsStats::setInfoKey
  - Flow::setL7JSON
  - CustomFlowLuaScriptAlert::setAlertMessage
  - CustomHostLuaScriptAlert::setAlertMessage, ctor (_msg)
  - ScanRealtimeAlert ctor (_alerts, std::vector)
  - CustomHostLuaScript::allocAlert (_msg)
  - OtherAlertableEntity::getAlertCachedValue / setAlertCacheValue / triggerAlert / releaseAlert (key, value)
  - HostAlert::init and HostAlert(HostCheckID, ...) ctor (_check_name)
  - Ntop::luaFlowCheckInfo / luaHostCheckInfo (check_name)
  - Ntop::incBlacklisHits (listname)
  - Ntop::setLuaCache (key, val)


