### PR TITLE
cppcheck: second batch of fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -268,9 +268,27 @@ Makefile: configure Makefile.in
 #	@echo ""
 #	./autogen.sh
 
+# Checks intentionally silenced (see doc/README.cppcheck or commit log):
+#  useInitializationList/duplInheritedMember/noCopyConstructor/noOperatorEq
+#    - style/opinion, not applicable to this codebase
+#  postfixOperator            - it++ on iterators, no measurable cost here
+#  memsetClassFloat           - memset(...,0,...) is a valid zero for IEEE-754
+#  virtualCallInConstructor/Destructor - deliberate (base behaviour wanted)
+#  nullPointer in the Lua engine files - false positives from the
+#    `getLuaVMContext(a) (a ? ... : NULL)` macro; the lua_State* is never NULL
+#    inside a Lua C function (scoped so real null derefs elsewhere still show)
+CPPCHECK_SUPPRESS = --suppress=useInitializationList --suppress=duplInheritedMember \
+                    --suppress=noCopyConstructor --suppress=noOperatorEq \
+                    --suppress=postfixOperator --suppress=memsetClassFloat \
+                    --suppress=virtualCallInConstructor --suppress=virtualCallInDestructor \
+                    --suppress=nullPointer:src/LuaEngineInterface.cpp \
+                    --suppress=nullPointer:src/LuaEngineNetwork.cpp \
+                    --suppress=nullPointer:src/LuaEngineNtop.cpp \
+                    --suppress=nullPointer:src/SNMP.cpp
+
 cppcheck:
 	@mkdir -p .cppcheck-build
-	cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=warning,performance,portability --suppress=useInitializationList --suppress=duplInheritedMember --suppress=noCopyConstructor --suppress=noOperatorEq -j $(shell nproc) --cppcheck-build-dir=.cppcheck-build -I include/ $(PRO_CPPCHECK_INCS) @HIREDIS_INC@ $(MONGOOSE_INC) $(JSON_INC) $(NDPI_INC) $(LUA_INC) $(CLICKHOUSE_INC) $(LIBRRDTOOL_INC) $(ZEROMQ_INC) src/*.cpp $(PRO_CPPCHECK_SRCS)
+	cppcheck --template='{file}:{line}:{severity}:{message}' --quiet --enable=warning,performance,portability $(CPPCHECK_SUPPRESS) -j $(shell nproc) --cppcheck-build-dir=.cppcheck-build -I include/ $(PRO_CPPCHECK_INCS) @HIREDIS_INC@ $(MONGOOSE_INC) $(JSON_INC) $(NDPI_INC) $(LUA_INC) $(CLICKHOUSE_INC) $(LIBRRDTOOL_INC) $(ZEROMQ_INC) src/*.cpp $(PRO_CPPCHECK_SRCS)
 
 test: test_version
 

--- a/include/Flow.h
+++ b/include/Flow.h
@@ -1655,7 +1655,8 @@ class Flow : public GenericHashEntry {
     return (ndpiAddressFamilyProtocol);
   }
   inline void setAddressFamilyProtocol(char* proto) {
-    ndpiAddressFamilyProtocol = strdup(proto);
+    if (ndpiAddressFamilyProtocol) free(ndpiAddressFamilyProtocol);
+    ndpiAddressFamilyProtocol = proto ? strdup(proto) : NULL;
   }
 
   inline ndpi_confidence_t getConfidence() { return (confidence); }

--- a/src/GenericTrafficElement.cpp
+++ b/src/GenericTrafficElement.cpp
@@ -48,6 +48,7 @@ void GenericTrafficElement::resetStats() {
   sent = TrafficStats();
   rcvd = TrafficStats();
   bytes_thpt.resetStats();
+  bytes_thpt_diff = 0;
   pkts_thpt.resetStats();
   tcp_packet_stats_sent = TcpPacketStats();
   tcp_packet_stats_rcvd = TcpPacketStats();
@@ -60,6 +61,7 @@ GenericTrafficElement::GenericTrafficElement(const GenericTrafficElement& gte) {
       (gte.ndpiStats) ? new (std::nothrow) nDPIStats(*gte.ndpiStats) : NULL;
 
   bytes_thpt = ThroughputStats(gte.bytes_thpt);
+  bytes_thpt_diff = gte.bytes_thpt_diff;
   pkts_thpt = ThroughputStats(gte.pkts_thpt);
 
   /* Stats */

--- a/src/HTTPserver.cpp
+++ b/src/HTTPserver.cpp
@@ -226,7 +226,7 @@ static void generate_csrf_token(char* csrf) {
   snprintf(random_b, sizeof(random_b), "%lu", time(NULL) * rand());
 #endif
 
-  mg_md5(csrf, random_a, random_b, NULL);
+  mg_md5(csrf, random_a, random_b, (char *) NULL);
 }
 
 /* ****************************************** */
@@ -327,7 +327,7 @@ static void generate_session_id(char* buf, const char* user,
 	     rand(), num_pkts, user);
   }
 
-  mg_md5(buf, random_str, user, group, NULL);
+  mg_md5(buf, random_str, user, group, (char *) NULL);
 }
 
 /* ****************************************** */

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2409,10 +2409,11 @@ void Host::releaseAllEngagedAlerts() {
 bool Host::triggerAlert(HostAlert* alert) {
   ScoreCategory score_category;
   HostAlertType alert_type;
-  u_int64_t alert_rowid = alert->getRowID();
+  u_int64_t alert_rowid;
 
   if (alert == NULL) return false;
 
+  alert_rowid = alert->getRowID();
   alert_type = alert->getAlertType();
 
   if (ntop->getPrefs()->dontEmitHostAlerts() /* all host alerts disabled */ ||

--- a/src/IpAddress.cpp
+++ b/src/IpAddress.cpp
@@ -176,7 +176,7 @@ void IpAddress::checkIP() {
       if (!ntop->isBroadcastIPDisabled() && nmask_bits > 0 &&
           nmask_bits < 31) { /* /0 no mask, /32 is just an host, /31 is a
                                 point-to-point */
-        nmask = ~((1 << (32 - nmask_bits)) - 1);
+        nmask = ~(((u_int32_t)1 << (32 - nmask_bits)) - 1);
         if (a == (a |
                   ~nmask) /* e.g., 10.0.0.0/8 -> matches 10.255.255.255.255 */
             || a == (a & nmask) /* e.g., 10.0.0.0/8 -> matches 10.0.0.0 */)

--- a/src/LuaEngineNtop.cpp
+++ b/src/LuaEngineNtop.cpp
@@ -5525,7 +5525,7 @@ static int ntop_md5(lua_State* vm) {
   if (ntop_lua_check(vm, __FUNCTION__, 1, LUA_TSTRING) != CONST_LUA_OK)
     return (ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_NO_RETURN_VALUE));
 
-  mg_md5(result, lua_tostring(vm, 1), NULL);
+  mg_md5(result, lua_tostring(vm, 1), (char *) NULL);
 
   lua_pushstring(vm, result);
   return (ntop_lua_return_value(vm, __FUNCTION__, CONST_LUA_ONE_RETURN_VALUE));

--- a/src/Ntop.cpp
+++ b/src/Ntop.cpp
@@ -1720,7 +1720,7 @@ bool Ntop::checkLocalAuth(const char* user, const char* password,
   if (!getUserPasswordHashLocal(user, val, sizeof(val))) {
     return (false);
   } else {
-    mg_md5(password_hash, password, NULL);
+    mg_md5(password_hash, password, (char *) NULL);
 
     if (strcmp(password_hash, val) != 0) {
       return (false);
@@ -2193,7 +2193,7 @@ bool Ntop::resetUserPassword(char* username, char* old_password,
   }
 
   snprintf(key, sizeof(key), CONST_STR_USER_PASSWORD, username);
-  mg_md5(password_hash, new_password, NULL);
+  mg_md5(password_hash, new_password, (char *) NULL);
 
   if (ntop->getRedis()->set(key, password_hash, 0) < 0) return (false);
 
@@ -2250,10 +2250,12 @@ bool Ntop::changeAllowedNets(char* username, char* allowed_nets) const {
 /* ******************************************* */
 
 bool Ntop::changeAllowedIfname(char* username, char* allowed_ifname) const {
-  /* Add as exception :// */
-  char* column_slash = strstr(allowed_ifname, ":__");
+  char* column_slash;
 
   if (username == NULL || username[0] == '\0') return false;
+
+  /* Add as exception :// */
+  column_slash = allowed_ifname ? strstr(allowed_ifname, ":__") : NULL;
 
   if (column_slash) column_slash[1] = column_slash[2] = '/';
 
@@ -2552,7 +2554,7 @@ bool Ntop::addUser(char* username, char* full_name, char* password,
   ntop->getRedis()->set(key, new_user_id_buf, 0);
 
   snprintf(key, sizeof(key), CONST_STR_USER_PASSWORD, username);
-  mg_md5(password_hash, password, NULL);
+  mg_md5(password_hash, password, (char *) NULL);
   ntop->getRedis()->set(key, password_hash, 0);
 
   snprintf(key, sizeof(key), CONST_STR_USER_NETS, username);
@@ -2849,7 +2851,7 @@ bool Ntop::createMFAPendingToken(const char* username, const char* referer,
 
   snprintf(random, sizeof(random), "%d%s", rand(), username);
   /* mg_md5 produces a 33-char (32 hex + NUL) string */
-  mg_md5(tmp_token, random, NULL);
+  mg_md5(tmp_token, random, (char *) NULL);
   strncpy(token, tmp_token, token_len - 1);
   token[token_len - 1] = '\0';
 
@@ -3212,7 +3214,7 @@ bool Ntop::createWebAuthnPendingToken(const char* username, const char* referer,
   if (!generateWebAuthnChallenge(challenge_b64, challenge_len)) return false;
 
   snprintf(rand_str, sizeof(rand_str), "%d%s", rand(), username);
-  mg_md5(tmp_token, rand_str, NULL);
+  mg_md5(tmp_token, rand_str, (char *) NULL);
   strncpy(token, tmp_token, token_len - 1);
   token[token_len - 1] = '\0';
 

--- a/src/ParsedFlowCore.cpp
+++ b/src/ParsedFlowCore.cpp
@@ -31,6 +31,9 @@ ParsedFlowCore::ParsedFlowCore() {
   memset(&src_mac, 0, sizeof(src_mac));
   memset(&dst_mac, 0, sizeof(dst_mac));
   memset(&exporter_device_ip, 0, sizeof(exporter_device_ip));
+  memset(&mapped_exporter_device_ip, 0, sizeof(mapped_exporter_device_ip));
+  memset(&next_hop, 0, sizeof(next_hop));
+  memset(&mapped_next_hop, 0, sizeof(mapped_next_hop));
   src_tos = dst_tos = 0;
   version = 0;
   memset(&nprobe_ip, 0, sizeof(nprobe_ip));
@@ -60,6 +63,10 @@ ParsedFlowCore::ParsedFlowCore(const ParsedFlowCore& pfc) {
   memcpy(&dst_mac, &pfc.dst_mac, sizeof(dst_mac));
   memcpy(&exporter_device_ip, &pfc.exporter_device_ip,
          sizeof(exporter_device_ip));
+  memcpy(&mapped_exporter_device_ip, &pfc.mapped_exporter_device_ip,
+         sizeof(mapped_exporter_device_ip));
+  memcpy(&next_hop, &pfc.next_hop, sizeof(next_hop));
+  memcpy(&mapped_next_hop, &pfc.mapped_next_hop, sizeof(mapped_next_hop));
   version = pfc.version;
   memcpy(&nprobe_ip, &pfc.nprobe_ip, sizeof(struct ndpi_in6_addr));
   unique_source_id = pfc.unique_source_id;

--- a/src/Redis.cpp
+++ b/src/Redis.cpp
@@ -1489,7 +1489,7 @@ int Redis::lrpop(const char* queue_name, char** buf, bool lpop) {
 
   if (reply && reply->str) {
     *buf = (char*)strdup(reply->str);
-    if(buf) rc = 0; else rc = -2;
+    if (*buf) rc = 0; else rc = -2;
   } else
     *buf = NULL, rc = -1;
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -3412,6 +3412,11 @@ char* Utils::get2ndLevelDomain(char* _domainname) {
 char* Utils::tokenizer(char* arg, int c, char** data) {
   char* p = NULL;
 
+  if (arg == NULL) {
+    if (data) *data = NULL;
+    return NULL;
+  }
+
   if ((p = strchr(arg, c)) != NULL) {
     *p = '\0';
     if (data) {
@@ -4655,7 +4660,7 @@ u_int32_t Utils::parsetime(char* str) {
 
     if (op == '\0')
       return (ret);
-    else if (sscanf(&str[4], "%d%s", &v, what) == 2) {
+    else if (sscanf(&str[4], "%d%63s", &v, what) == 2) {
       if (!strcmp(what, "h"))
         v *= 3600;
       else if (!strcmp(what, "d"))
@@ -6138,7 +6143,7 @@ void Utils::splitAddressAndVlan(char* addr, u_int16_t* vlan_id) {
     *vlan_id = atoi(at + 1);
     *at = '\0';
   } else
-    vlan_id = 0;
+    *vlan_id = 0;
 }
 
 /* ******************************************* */


### PR DESCRIPTION
1. Makefile.in - extend the suppression list

Moved the --suppress flags into a CPPCHECK_SUPPRESS variable (the recipe line was getting unreadable) and added, with a comment block explaining each:

  postfixOperator          22x `it++` on non-primitive iterators. No
                           measurable cost for the iterator types used
                           here; "fixing" is 22 churn-only edits.

  memsetClassFloat         13x `memset(&x, 0, sizeof(x))` on a struct that
                           contains a float/double. All-zero bytes is a
                           valid 0.0 / 0.0f on every platform ntopng
                           targets (IEEE-754); this is the idiomatic way
                           the codebase zeroes POD-ish structs.

  virtualCallInConstructor  7x  cleanup()/allocateStats()/toggleRxOnlyHost()
  virtualCallInDestructor       /walker() are deliberately called from a
                           ctor/dtor where the *base* implementation is the
                           intended one. Refactoring is invasive and risky.

  nullPointer (path-scoped to src/LuaEngineInterface.cpp,
              src/LuaEngineNetwork.cpp, src/LuaEngineNtop.cpp, src/SNMP.cpp)
                           14x false positives from
                             #define getLuaVMContext(a) (a ? getUserdata(a) : NULL)
                           and getLuaVMUserdata(): cppcheck treats the
                           ": NULL" branch as reachable, but the lua_State*
                           is never NULL inside a Lua C function. Scoped by
                           file so a real null deref elsewhere still shows.

2. Real bugs fixed

src/Utils.cpp  Utils::splitAddressAndVlan()
  The no-'@vlan' branch did `vlan_id = 0;` - assigning the *local pointer*
  parameter instead of `*vlan_id = 0;`. Result: when the address had no
  "@<vlan>" suffix, the caller's vlan_id was left uninitialised (garbage)
  instead of being set to 0. Fixed to `*vlan_id = 0;`.
  (cppcheck: uselessAssignmentPtrArg)

src/Utils.cpp  Utils::parsetime()
  `sscanf(&str[4], "%d%s", &v, what)` with `char what[64]` - unbounded %s,
  stack buffer overflow for a long time spec (these strings come from REST
  parameters such as epoch_begin=now+...). Bounded to "%d%63s".
  (cppcheck: invalidscanf)

src/Utils.cpp  Utils::tokenizer()
  `strchr(arg, c)` was called before the function's own `if (arg)` guard a
  few lines down - inconsistent, and a crash if a caller ever passes NULL
  (which the later guard shows was considered possible). Added an
  arg == NULL early return (sets *data = NULL, returns NULL) at the top.
  (cppcheck: nullPointerRedundantCheck)

src/IpAddress.cpp  IpAddress::isLocalInterfaceAddress() (broadcast calc)
  `~((1 << (32 - nmask_bits)) - 1)` with nmask_bits in 1..30 -> the shift
  count reaches 31, i.e. `1 << 31` on a signed int = shift into the sign
  bit, which is implementation-defined / UB. Changed the literal to
  `(u_int32_t)1`. `nmask` is already u_int32_t.
  (cppcheck: shiftTooManyBitsSigned)

src/HTTPserver.cpp (x2), src/Ntop.cpp (x5), src/LuaEngineNtop.cpp (x1)
  `mg_md5(buf, a, b, NULL)` - mg_md5() is variadic and stops at a NULL
  string pointer, but a bare `NULL` may be passed as `int 0` (only
  well-defined when NULL is a pointer constant of the right width). Passing
  `(char *) NULL` makes the sentinel explicitly pointer-typed. No
  behavioural change on LP64 Linux/macOS; removes the UB.
  (cppcheck: varFuncNullUB)

include/Flow.h  Flow::setAddressFamilyProtocol()
  `ndpiAddressFamilyProtocol = strdup(proto);` with no free of the previous
  value and no NULL check on `proto`. The setter can be called more than
  once per flow as detection progresses -> each subsequent call leaked the
  previous strdup() (the destructor only frees the last one). Now frees the
  old buffer first and guards `proto == NULL`.
  (cppcheck: publicAllocationError)

src/ParsedFlowCore.cpp  both constructors
  Neither the default ctor nor the copy ctor initialised next_hop,
  mapped_next_hop and mapped_exporter_device_ip (struct ndpi_in6_addr, used
  for collected/SNMP-mapped next-hop and exporter addresses). Default ctor
  now memset()s them; copy ctor now memcpy()s them from the source.
  (cppcheck: uninitMemberVar / missingMemberCopy)

src/GenericTrafficElement.cpp  bytes_thpt_diff
  `float bytes_thpt_diff` was never initialised in resetStats() (called by
  the default ctor) nor copied by the copy ctor. Initialised to 0 in
  resetStats() and copied in the copy ctor. (This member currently has no
  other reader in the tree, so the effect is limited, but the copy ctor was
  literally reading an uninitialised float.)
  (cppcheck: uninitMemberVar / missingMemberCopy)

src/Host.cpp  Host::triggerAlert()
  `u_int64_t alert_rowid = alert->getRowID();` ran *before*
  `if (alert == NULL) return false;` - the null check right after it is
  pointless if the deref already happened. Moved the assignment below the
  check.
  (cppcheck: nullPointerRedundantCheck)

src/Redis.cpp  Redis::lrpop()
  After `*buf = strdup(reply->str);` the code did `if (buf) rc = 0; else
  rc = -2;` - `buf` is the `char **` parameter and is always non-NULL, so
  the strdup-failure branch (rc = -2) was dead. Changed to `if (*buf)`.
  (cppcheck: nullPointerRedundantCheck)

src/Ntop.cpp  Ntop::changeAllowedIfname()
  `strstr(allowed_ifname, ":__")` at the top of the function, while the
  body a few lines later checks `allowed_ifname != NULL && allowed_ifname[0]`
  - inconsistent, and a crash if allowed_ifname is NULL. Reordered so the username guard runs first, then the strstr is done only when allowed_ifname is non-NULL. (cppcheck: nullPointerRedundantCheck)


