### PR TITLE
bound detunneled eth_offset to caplen in dissectPacket

### DIFF
--- a/src/NetworkInterface.cpp
+++ b/src/NetworkInterface.cpp
@@ -3054,7 +3054,7 @@ datalink_check:
     if (sender_mac) memcpy(&dummy_ethernet.h_source, sender_mac, 6);
     ip_offset = 4 + eth_offset;
   } else if (datalink_type == DLT_EN10MB) {
-    if (h->caplen < sizeof(ndpi_ethhdr)) {
+    if ((eth_offset + sizeof(ndpi_ethhdr)) > h->caplen) {
       incStats(ingressPacket, h->ts.tv_sec, 0, NDPI_PROTOCOL_UNKNOWN,
                NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, 0, h->len, 1,
                NULL /* srcMac */, NULL /* dstMac */);
@@ -3065,7 +3065,7 @@ datalink_check:
     ip_offset = sizeof(struct ndpi_ethhdr) + eth_offset;
     eth_type = ntohs(ethernet->h_proto);
   } else if (datalink_type == 276 /* Linux Cooked Capture v2 */) {
-    if (h->caplen < 20) {
+    if ((eth_offset + 20) > h->caplen) {
       incStats(ingressPacket, h->ts.tv_sec, 0, NDPI_PROTOCOL_UNKNOWN,
                NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, 0, h->len, 1,
                NULL /* srcMac */, NULL /* dstMac */);
@@ -3077,7 +3077,7 @@ datalink_check:
     eth_type = (packet[eth_offset] << 8) + packet[eth_offset + 1];
     ip_offset = 20 + eth_offset;
   } else if (datalink_type == 113 /* Linux Cooked Capture */) {
-    if (h->caplen < 16) {
+    if ((eth_offset + 16) > h->caplen) {
       incStats(ingressPacket, h->ts.tv_sec, 0, NDPI_PROTOCOL_UNKNOWN,
                NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, 0, h->len, 1,
                NULL /* srcMac */, NULL /* dstMac */);
@@ -3092,7 +3092,7 @@ datalink_check:
   } else if (datalink_type ==
                  DLT_RAW /* Linux TUN/TAP device in TUN mode; Raw IP capture */
              || datalink_type == 14 /* raw IP DLT_RAW on OpenBSD captures */) {
-    if (h->caplen < sizeof(u_int32_t)) {
+    if ((eth_offset + sizeof(u_int32_t)) > h->caplen) {
       incStats(ingressPacket, h->ts.tv_sec, 0, NDPI_PROTOCOL_UNKNOWN,
                NDPI_PROTOCOL_CATEGORY_UNSPECIFIED, 0, h->len, 1,
                NULL /* srcMac */, NULL /* dstMac */);


### PR DESCRIPTION
Please sign (check) the below before submitting the Pull Request:

- [x] I have signed the ntop Contributor License Agreement at https://github.com/ntop/legal/blob/main/individual-contributor-licence-agreement.md
- [x] I have read the contributing guide lines https://github.com/ntop/ntopng/blob/dev/CONTRIBUTING.md
- [ ] I have updated the documentation (in doc/src/) to reflect the changes made (if applicable)

Link to the related [issue](https://github.com/ntop/ntopng/issues):

N/A

Describe changes:

With tunnel decoding enabled (-T), the VXLAN, EOIP, GRE Transparent Ethernet Bridging/ERSPAN, and TZSP decoders set `eth_offset` and `goto datalink_check` to re-parse the inner Ethernet frame. Those decoders can leave `eth_offset` equal to or past `h->caplen`: VXLAN and EOIP add their header lengths with no bounds check, and the GRE TEB/ERSPAN path only checks `h->caplen >= offset`. The `DLT_EN10MB` branch then validates the total `h->caplen` against `sizeof(ndpi_ethhdr)` rather than against `eth_offset`, and reads `ethernet->h_proto` at `packet[eth_offset + 12]`. A short tunneled UDP datagram that ends right after the outer UDP header reads past the captured packet buffer. The Linux cooked (113/276) and DLT_RAW branches carry the same `eth_offset`-relative reads guarded only by total `caplen`.

Before, only the `DLT_NULL` branch guarded its read with `eth_offset + size <= h->caplen`; after, the four other branches use the same form. Keeping the bound in the shared datalink parser covers every tunnel decoder that re-enters it, present and future, instead of repeating the check at each `goto`. The only behavioral trade-off is for `eth_offset == 0` (non-tunneled traffic), where the new condition is identical to the old one, so normal captures are unaffected.
