### PR TITLE
Fix parsing of malformed MDNS packets

### DIFF
--- a/src/Flow.cpp
+++ b/src/Flow.cpp
@@ -7208,6 +7208,8 @@ void Flow::dissectMDNS(u_int8_t* payload, u_int16_t payload_len) {
         const u_int8_t max_nested_loops = 8;
 
       nested_dns_definition:
+        if (i + 1 >= payload_len)
+          return; /* Invalid packet */
         offset = payload[i + 1] - 12;
         i = offset;
 


### PR DESCRIPTION
```
=================================================================
==235673==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x78cbfbe106fc at pc 0x63c3c9352b9d bp 0x7ffe23107470 sp 0x7ffe23107468
READ of size 1 at 0x78cbfbe106fc thread T0
    #0 0x63c3c9352b9c in Flow::dissectMDNS(unsigned char*, unsigned short) /home/ivan/svnrepos/ntopng-fuzz/src/Flow.cpp:7211:18
    #1 0x63c3c9539bc9 in NetworkInterface::processPacket(int, unsigned int, int, bool*, timeval const*, unsigned long, ndpi_ethhdr*, unsigned short, ndpi_iphdr*, ndpi_ipv6hdr*, unsigned short, unsigned short, unsigned int, pcap_pkthdr const*, unsigned char const*, unsigned short*, Host**, Host**, Flow**, bool*, unsigned char*) /home/ivan/svnrepos/ntopng-fuzz/src/NetworkInterface.cpp:2720:15
    #2 0x63c3c95488ea in NetworkInterface::dissectPacket(int, unsigned int, int, bool, unsigned char*, pcap_pkthdr const*, unsigned char const*, unsigned short*, Host**, Host**, Flow**) /home/ivan/svnrepos/ntopng-fuzz/src/NetworkInterface.cpp:3836:28
```
Found by oss-fuzz


